### PR TITLE
Update GCSPROXY_VERSION to 0.4.2 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:buster-slim AS build
 
 WORKDIR /tmp
-ARG GCSPROXY_VERSION=0.3.1
+ARG GCSPROXY_VERSION=0.4.2
 
 RUN apt-get update \
     && apt-get install --no-install-suggests --no-install-recommends --yes ca-certificates wget \


### PR DESCRIPTION
Had an issue with our local usage before we realized that we were building a much older version due to it being specified in the example `Dockerfile`. Offering a quick fix to spare others from similar confusion.