### PR TITLE
Add -s option to enforce source bucket name

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,22 @@ Usage of gcsproxy:
         The path to the keyfile. If not present, client will use your default application credentials.
   -i string
         The default index file to serve.
+  -s string
+        The source bucket name. If not present, bucket name will be extracted from the path.
   -v    Show access log
 
 ```
 
-The gcsproxy routing configuration is shown below.
+The default gcsproxy routing configuration is shown below.
 
-`"/{bucket:[0-9a-zA-Z-_.] +}/{object:. *}"`
+`"/{bucket:[0-9a-zA-Z-_.]+}/{object:.*}"`
 
 If you are running gcsproxy on localhost:8080 and you want to access the file `gs://test-bucket/your/file/path.txt` in GCS via gcsproxy,
 you can use the URL You can access the file via gcsproxy at the URL `http://localhost:8080/test-bucket/your/file/path.txt`.
+
+Specifying the `-s` option fixes the bucket name to the given value and following routing configuration is used instead.
+
+`"/{object:.*}"`
 
 If a default index file is specified and the target object does not exist, an attempt is made to retrieve the object specified in the default index file.
 


### PR DESCRIPTION
## Summary
This pull request introduces a new `-s` CLI option that allows specifying a bucket name directly instead of extracting it from the requested paths.

## My use case
I'm hosting a private website with a private bucket protected by [Identity-Aware Proxy (IAP)](https://cloud.google.com/security/products/iap?hl=ja).

```mermaid
flowchart LR
  http(http)---LB-with-IAP
  subgraph LB-with-IAP
    direction TB
    A[Identity-Aware Proxy].->B[Application Load Balancer]
  end
  LB-with-IAP---cloud-run[Cloud Run - gcsproxy]
  cloud-run---bucket[(Private Bucket)]  
```

The [path rewriting](https://cloud.google.com/load-balancing/docs/https/setting-up-url-rewrite) feature provided by the load balancer can be used to pass the bucket name to gcsproxy. 

However, this setup creates an issue when combined with IAP. When IAP is enabled, it processes requests after the path has been rewritten. As a result, the redirect URL after completing the authentication flow will include the rewritten path prefix, which is unintended. Using the new `-s` option instead of path rewriting resolves this issue.
