### PR TITLE
Add goreleaser docker build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,12 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.23'
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -44,3 +44,42 @@ changelog:
       - 'README'
       - Merge pull request
       - Merge branch
+
+# Push arch specific images (push is required for multi-arch manifests)
+dockers:
+  - image_templates:
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:{{ .Version }}-amd64"
+    use: buildx
+    goos: linux
+    goarch: amd64
+    dockerfile: Dockerfile.goreleaser
+    build_flag_templates:
+      - "--platform=linux/amd64"
+  - image_templates:
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:{{ .Version }}-arm64"
+    use: buildx
+    goos: linux
+    goarch: arm64
+    dockerfile: Dockerfile.goreleaser
+    build_flag_templates:
+      - "--platform=linux/arm64"
+
+# Push multi-arch manifests
+docker_manifests:
+  # Github Container Registry
+  - name_template: "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:{{ .Version }}-amd64"
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:{{.Major}}.{{.Minor}}"
+    image_templates:
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:{{ .Version }}-amd64"
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:{{ .Version }}-arm64"
+
+release:
+  footer: |
+    ## Docker images
+    [Packages gcsproxy](https://github.com/{{ .Env.GITHUB_REPOSITORY }}/pkgs/container/gcsproxy)
+    ```shell
+    docker pull ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:{{ .Version }}
+    ```

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 before:
   hooks:
     - go mod download
@@ -20,11 +22,11 @@ builds:
         goarch: 386
 
 archives:
-  - format: tar.gz
+  - formats: ['tar.gz']
     wrap_in_directory: true
     format_overrides:
       - goos: windows
-        format: zip
+        formats: ['zip']
     name_template: '{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     files:
       - LICENSE
@@ -34,7 +36,7 @@ checksum:
   name_template: 'checksums.txt'
 
 snapshot:
-  name_template: "SNAPSHOT-{{ .Tag }}"
+  version_template: "SNAPSHOT-{{ .Tag }}"
 
 changelog:
   sort: asc

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,4 @@
+FROM gcr.io/distroless/base
+COPY gcsproxy /gcsproxy
+ENTRYPOINT ["/gcsproxy"]
+CMD [ "-b", "0.0.0.0:80" ]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ This is a reverse proxy for Google Cloud Storage for performing limited disclosu
 +------------+          +---------------+
 ```
 
+## Download
+
+Download the latest version of gcsproxy from the [Github Releases page](https://github.com/daichirata/gcsproxy/releases).
+
 ## Usage
 
 ```
@@ -88,7 +92,7 @@ docker run \
     -it --rm \
     -p 8080:80 \
     -e GOOGLE_APPLICATION_CREDENTIALS=/cred.json \
-    -v $(pwd)/../d53ee11da87c.json:/cred.json gcsproxy 
+    -v $(pwd)/../d53ee11da87c.json:/cred.json gcsproxy
 ```
 
 ### Docker Compose example


### PR DESCRIPTION
This PR adds a published Docker image built with goreleaser and pushed to the Github Container Registry (ghcr.io).

Additionally:
- Includes a reference to the published image in the github release notes
- Adds a download section to the readme directing users to the github releases page
- Fixes goreleaser deprecations