### PR TITLE
[codex] update goreleaser v2 config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 before:
   hooks:
     - go mod download
@@ -20,11 +22,11 @@ builds:
         goarch: 386
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     wrap_in_directory: true
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
     name_template: '{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     files:
       - LICENSE

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/daichirata/gcsproxy
 
-go 1.24.5
+go 1.24
 
 require (
 	cloud.google.com/go/storage v1.56.0


### PR DESCRIPTION
## What changed
- added `version: 2` to `.goreleaser.yml`
- updated archive settings from deprecated `format` keys to `formats`
- normalized `go.mod` Go version from `1.24.5` to `1.24`

## Why
- align the release configuration with GoReleaser v2 schema
- remove deprecated archive config usage
- keep the Go version declaration consistent with the release workflow

## Impact
- release builds should continue to work with current GoReleaser v2 expectations
- no application runtime behavior changes are intended

## Validation
- `go test ./...`
