### PR TITLE
feat: add -spa and -not-found options

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ gcsproxy lets you keep a GCS bucket private while still serving its objects over
 - Negotiates `Content-Encoding: gzip` when the client accepts it
 - Optional default index file (`-i`) for serving static sites
 - Optional fixed bucket (`-bucket`) for hosting a single bucket without exposing its name in URLs
+- Optional SPA fallback (`-spa`) that returns the index file with HTTP 200 for unmatched routes
+- Optional custom not-found page (`-not-found`) served with HTTP 404 for unmatched routes
 - `/_health` endpoint for liveness/readiness probes
 
 ## Installation
@@ -56,6 +58,10 @@ Usage of gcsproxy:
         Fixed bucket name. If unset, the bucket is taken from the first path segment.
   -i string
         The default index file to serve.
+  -not-found string
+        Object path served with HTTP 404 when no object matches the request. Mutually exclusive with -spa.
+  -spa
+        Single-page application fallback. When a request does not match an object, serve the -i index file from the bucket root with HTTP 200. Requires -i; mutually exclusive with -not-found.
   -v    Show access log
 ```
 
@@ -86,6 +92,30 @@ gcsproxy -i index.html
 
 GET /test-bucket/foo/bar
   -> gs://test-bucket/foo/bar/index.html
+```
+
+### SPA fallback
+
+When `-spa` is set together with `-i`, any request that fails to resolve — even after the `-i` lookup — serves the configured index file from the bucket root with HTTP 200. This is the standard pattern for client-side-routed apps (React, Vue, etc.):
+
+```
+gcsproxy -i index.html -spa
+
+GET /test-bucket/some/spa/route
+  -> gs://test-bucket/index.html  (HTTP 200)
+```
+
+This mirrors [Cloudflare Workers'](https://developers.cloudflare.com/workers/static-assets/routing/single-page-application/) `not_found_handling = "single-page-application"` and [Netlify's](https://docs.netlify.com/manage/routing/redirects/rewrites-proxies/) `/* /index.html 200` rewrite. `-spa` requires `-i` to be set and is mutually exclusive with `-not-found`.
+
+### Custom not-found page
+
+When `-not-found <path>` is set, requests that fail to resolve serve the given object with HTTP 404 instead of the default plain-text 404. The object's `Content-Type` and other headers are forwarded as-is:
+
+```
+gcsproxy -not-found 404.html
+
+GET /test-bucket/missing
+  -> gs://test-bucket/404.html  (HTTP 404)
 ```
 
 ### Health check

--- a/main.go
+++ b/main.go
@@ -24,6 +24,8 @@ var (
 	credentialsFile = flag.String("c", "", "The path to the keyfile. If not present, client will use your default application credentials.")
 	defaultIndex    = flag.String("i", "", "The default index file to serve.")
 	sourceBucket    = flag.String("bucket", "", "Fixed bucket name. If unset, the bucket is taken from the first path segment.")
+	spa             = flag.Bool("spa", false, "Single-page application fallback. When a request does not match an object, serve the -i index file from the bucket root with HTTP 200. Requires -i; mutually exclusive with -not-found.")
+	notFoundPath    = flag.String("not-found", "", "Object path served with HTTP 404 when no object matches the request. Mutually exclusive with -spa.")
 )
 
 var client *storage.Client
@@ -129,6 +131,17 @@ func fetchObjectAttrs(ctx context.Context, bucket, object string) (*storage.Obje
 func proxy(w http.ResponseWriter, r *http.Request, bucket, object string) {
 	attrs, err := fetchObjectAttrs(r.Context(), bucket, object)
 	if err != nil {
+		if errors.Is(err, storage.ErrObjectNotExist) {
+			if *spa && *defaultIndex != "" {
+				if serveErr := serveObject(w, r, bucket, *defaultIndex, http.StatusOK); serveErr == nil {
+					return
+				}
+			} else if *notFoundPath != "" {
+				if serveErr := serveObject(w, r, bucket, *notFoundPath, http.StatusNotFound); serveErr == nil {
+					return
+				}
+			}
+		}
 		handleError(w, err)
 		return
 	}
@@ -159,6 +172,28 @@ func proxy(w http.ResponseWriter, r *http.Request, bucket, object string) {
 	io.Copy(w, objr)
 }
 
+func serveObject(w http.ResponseWriter, r *http.Request, bucket, object string, status int) error {
+	attrs, err := client.Bucket(bucket).Object(object).Attrs(r.Context())
+	if err != nil {
+		return err
+	}
+	gzipAcceptable := strings.Contains(r.Header.Get("Accept-Encoding"), "gzip")
+	objr, err := client.Bucket(attrs.Bucket).Object(attrs.Name).ReadCompressed(gzipAcceptable).NewReader(r.Context())
+	if err != nil {
+		return err
+	}
+	setTimeHeader(w, "Last-Modified", attrs.Updated)
+	setStrHeader(w, "Content-Type", attrs.ContentType)
+	setStrHeader(w, "Content-Language", attrs.ContentLanguage)
+	setStrHeader(w, "Cache-Control", attrs.CacheControl)
+	setStrHeader(w, "Content-Encoding", objr.Attrs.ContentEncoding)
+	setStrHeader(w, "Content-Disposition", attrs.ContentDisposition)
+	setIntHeader(w, "Content-Length", objr.Attrs.Size)
+	w.WriteHeader(status)
+	io.Copy(w, objr)
+	return nil
+}
+
 func healthCheck(w http.ResponseWriter, r *http.Request) {
 	setStrHeader(w, "Content-Type", "text/plain")
 	io.WriteString(w, "OK\n")
@@ -183,6 +218,13 @@ func newRouter(sourceBucket string) http.Handler {
 
 func main() {
 	flag.Parse()
+
+	if *spa && *defaultIndex == "" {
+		log.Fatal("-spa requires -i to be set")
+	}
+	if *spa && *notFoundPath != "" {
+		log.Fatal("-spa and -not-found are mutually exclusive")
+	}
 
 	ctx := context.Background()
 	var opts []option.ClientOption

--- a/main_test.go
+++ b/main_test.go
@@ -166,6 +166,20 @@ func installTestClient(t *testing.T, srv *fakestorage.Server, idx string) {
 	})
 }
 
+func setSPA(t *testing.T, enabled bool) {
+	t.Helper()
+	prev := *spa
+	*spa = enabled
+	t.Cleanup(func() { *spa = prev })
+}
+
+func setNotFoundPath(t *testing.T, path string) {
+	t.Helper()
+	prev := *notFoundPath
+	*notFoundPath = path
+	t.Cleanup(func() { *notFoundPath = prev })
+}
+
 func TestProxy_OK(t *testing.T) {
 	srv := newTestServer(t, []fakestorage.Object{{
 		ObjectAttrs: fakestorage.ObjectAttrs{
@@ -432,5 +446,168 @@ func TestProxy_SourceBucket_HealthCheckStillWorks(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), "OK") {
 		t.Errorf("body = %q, want to contain %q", rec.Body.String(), "OK")
+	}
+}
+
+// --- SPA fallback (-spa) tests ---
+
+func TestProxy_SPA_FallbackToRootIndex(t *testing.T) {
+	srv := newTestServer(t, []fakestorage.Object{{
+		ObjectAttrs: fakestorage.ObjectAttrs{
+			BucketName:  testBucket,
+			Name:        "index.html",
+			ContentType: "text/html",
+		},
+		Content: []byte(testIndexBody),
+	}})
+	installTestClient(t, srv, "index.html")
+	setSPA(t, true)
+
+	rec := httptest.NewRecorder()
+	// Arbitrary path that doesn't exist as an object.
+	req := httptest.NewRequest(http.MethodGet, "/"+testBucket+"/some/spa/route", nil)
+	newRouter("").ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body=%q)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != testIndexBody {
+		t.Errorf("body = %q, want %q", got, testIndexBody)
+	}
+}
+
+func TestProxy_SPA_PassthroughForExistingObject(t *testing.T) {
+	srv := newTestServer(t, []fakestorage.Object{
+		{
+			ObjectAttrs: fakestorage.ObjectAttrs{BucketName: testBucket, Name: testObject, ContentType: testCType},
+			Content:     []byte(testContent),
+		},
+		{
+			ObjectAttrs: fakestorage.ObjectAttrs{BucketName: testBucket, Name: "index.html", ContentType: "text/html"},
+			Content:     []byte(testIndexBody),
+		},
+	})
+	installTestClient(t, srv, "index.html")
+	setSPA(t, true)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/"+testBucket+"/"+testObject, nil)
+	newRouter("").ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got := rec.Body.String(); got != testContent {
+		t.Errorf("body = %q, want %q (SPA should not override real objects)", got, testContent)
+	}
+}
+
+func TestProxy_SPA_NoRootIndexReturns404(t *testing.T) {
+	// SPA enabled but the root index.html itself does not exist.
+	srv := newTestServer(t, nil)
+	installTestClient(t, srv, "index.html")
+	setSPA(t, true)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/"+testBucket+"/whatever", nil)
+	newRouter("").ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestProxy_SPA_WithSourceBucket(t *testing.T) {
+	srv := newTestServer(t, []fakestorage.Object{{
+		ObjectAttrs: fakestorage.ObjectAttrs{
+			BucketName:  testBucket,
+			Name:        "index.html",
+			ContentType: "text/html",
+		},
+		Content: []byte(testIndexBody),
+	}})
+	installTestClient(t, srv, "index.html")
+	setSPA(t, true)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/deep/nested/route", nil)
+	newRouter(testBucket).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body=%q)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != testIndexBody {
+		t.Errorf("body = %q, want %q", got, testIndexBody)
+	}
+}
+
+// --- Custom not-found (-not-found) tests ---
+
+func TestProxy_NotFound_ServesCustomPage(t *testing.T) {
+	const notFoundBody = "<html>oops</html>"
+	srv := newTestServer(t, []fakestorage.Object{{
+		ObjectAttrs: fakestorage.ObjectAttrs{
+			BucketName:  testBucket,
+			Name:        "404.html",
+			ContentType: "text/html",
+		},
+		Content: []byte(notFoundBody),
+	}})
+	installTestClient(t, srv, "")
+	setNotFoundPath(t, "404.html")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/"+testBucket+"/missing.txt", nil)
+	newRouter("").ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d (body=%q)", rec.Code, http.StatusNotFound, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != notFoundBody {
+		t.Errorf("body = %q, want %q", got, notFoundBody)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "text/html" {
+		t.Errorf("Content-Type = %q, want %q", ct, "text/html")
+	}
+}
+
+func TestProxy_NotFound_NotInvokedForExistingObject(t *testing.T) {
+	srv := newTestServer(t, []fakestorage.Object{
+		{
+			ObjectAttrs: fakestorage.ObjectAttrs{BucketName: testBucket, Name: testObject, ContentType: testCType},
+			Content:     []byte(testContent),
+		},
+		{
+			ObjectAttrs: fakestorage.ObjectAttrs{BucketName: testBucket, Name: "404.html", ContentType: "text/html"},
+			Content:     []byte("should not be served"),
+		},
+	})
+	installTestClient(t, srv, "")
+	setNotFoundPath(t, "404.html")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/"+testBucket+"/"+testObject, nil)
+	newRouter("").ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got := rec.Body.String(); got != testContent {
+		t.Errorf("body = %q, want %q", got, testContent)
+	}
+}
+
+func TestProxy_NotFound_MissingPageFallsBackToDefault404(t *testing.T) {
+	// The configured not-found object itself doesn't exist in the bucket.
+	srv := newTestServer(t, nil)
+	installTestClient(t, srv, "")
+	setNotFoundPath(t, "404.html")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/"+testBucket+"/missing.txt", nil)
+	newRouter("").ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusNotFound)
 	}
 }


### PR DESCRIPTION
## Summary

Adds two opt-in flags for static-site hosting use cases:

- **`-spa`** — when a request does not resolve to an object, serve the configured `-i` index file from the bucket root with HTTP 200. Standard SPA fallback pattern (React/Vue/Angular client-side routing). Requires `-i`; mutually exclusive with `-not-found`.
- **`-not-found <path>`** — when a request does not resolve to an object, serve the given object with HTTP 404 instead of the default plain-text 404. Mirrors S3-style static hosting custom error documents.

The fallback only runs after the existing `-i` lookup also misses, so direct hits and per-directory `index.html` resolution are unchanged.

## Loosely related: #28

This was inspired by #28 (by @DeviaVir) which proposed a similar idea (custom 404 + walk-up to find `index.html`). The implementation here is a fresh take rather than a rebase:

- Split into two distinct **opt-in** flags so non-static-site users aren't affected
- Dropped the "walk up directories" behavior — modern static hosts (Cloudflare Pages, Netlify, S3) all use a fixed root index for SPA fallback rather than walking parents, which is the more predictable behavior
- Added tests (the test infrastructure landed in #45 since #28 was opened)

References:
- [Cloudflare Workers — SPA static assets routing](https://developers.cloudflare.com/workers/static-assets/routing/single-page-application/)
- [Netlify — Rewrites and proxies](https://docs.netlify.com/manage/routing/redirects/rewrites-proxies/)

## Behavioral matrix

| Flag combo | `/exists.txt` | `/missing` (no per-dir index) | `/dir/` (index.html exists) |
|---|---|---|---|
| (none) | object body, 200 | plain 404 | plain 404 |
| `-i index.html` | object body, 200 | plain 404 | `dir/index.html`, 200 |
| `-i index.html -spa` | object body, 200 | root `index.html`, **200** | `dir/index.html`, 200 |
| `-not-found 404.html` | object body, 200 | `404.html`, **404** | plain 404 |

## Test plan

- [x] `go test -race -count=1 ./...` passes locally (27 tests; +7 new)
- [x] `go vet ./...` passes
- [x] `go build ./...` passes
- [x] Startup validation: `-spa` without `-i` → fatal; `-spa` + `-not-found` → fatal
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)