### PR TITLE
feat: structured logging with -log-format text|json

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ gcsproxy lets you keep a GCS bucket private while still serving its objects over
 - Optional fixed bucket (`-bucket`) for hosting a single bucket without exposing its name in URLs
 - Optional SPA fallback (`-spa`) that returns the index file with HTTP 200 for unmatched routes
 - Optional custom not-found page (`-not-found`) served with HTTP 404 for unmatched routes
+- Structured logging via `log/slog` with text or JSON output (`-log-format`)
 - `/_health` endpoint for liveness/readiness probes
 
 ## Installation
@@ -58,6 +59,8 @@ Usage of gcsproxy:
         Fixed bucket name. If unset, the bucket is taken from the first path segment.
   -i string
         The default index file to serve.
+  -log-format string
+        Log output format: text or json. (default "text")
   -not-found string
         Object path served with HTTP 404 when no object matches the request. Mutually exclusive with -spa.
   -spa
@@ -117,6 +120,20 @@ gcsproxy -not-found 404.html
 GET /test-bucket/missing
   -> gs://test-bucket/404.html  (HTTP 404)
 ```
+
+### Logging
+
+gcsproxy uses Go's standard `log/slog` package and writes structured logs to stderr. The `-log-format` flag selects the output encoding:
+
+```
+gcsproxy -log-format json -v
+```
+
+```json
+{"time":"2026-05-21T09:00:00Z","level":"INFO","msg":"access","remote":"127.0.0.1","elapsed":0.0042,"status":200,"method":"GET","url":"/bucket/foo/bar"}
+```
+
+The default (`text`) is human-readable `key=value` output. JSON mode is intended for log aggregation pipelines like Cloud Logging, Datadog, or Loki. The access log line is only emitted when `-v` is set.
 
 ### Health check
 

--- a/main.go
+++ b/main.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -26,6 +28,7 @@ var (
 	sourceBucket    = flag.String("bucket", "", "Fixed bucket name. If unset, the bucket is taken from the first path segment.")
 	spa             = flag.Bool("spa", false, "Single-page application fallback. When a request does not match an object, serve the -i index file from the bucket root with HTTP 200. Requires -i; mutually exclusive with -not-found.")
 	notFoundPath    = flag.String("not-found", "", "Object path served with HTTP 404 when no object matches the request. Mutually exclusive with -spa.")
+	logFormat       = flag.String("log-format", "text", "Log output format: text or json.")
 )
 
 var client *storage.Client
@@ -89,12 +92,12 @@ func wrapper(fn func(w http.ResponseWriter, r *http.Request)) http.HandlerFunc {
 			addr = ip
 		}
 		if *verbose {
-			log.Printf("[%s] %.3f %d %s %s",
-				addr,
-				time.Now().Sub(proc).Seconds(),
-				writer.status,
-				r.Method,
-				r.URL,
+			slog.Info("access",
+				"remote", addr,
+				"elapsed", time.Since(proc).Seconds(),
+				"status", writer.status,
+				"method", r.Method,
+				"url", r.URL.String(),
 			)
 		}
 	}
@@ -148,7 +151,7 @@ func proxy(w http.ResponseWriter, r *http.Request, bucket, object string) {
 	if lastStrs, ok := r.Header["If-Modified-Since"]; ok && len(lastStrs) > 0 {
 		last, err := http.ParseTime(lastStrs[0])
 		if *verbose && err != nil {
-			log.Printf("could not parse If-Modified-Since: %v", err)
+			slog.Warn("could not parse If-Modified-Since", "err", err)
 		}
 		if !attrs.Updated.Truncate(time.Second).After(last) {
 			w.WriteHeader(304)
@@ -219,11 +222,23 @@ func newRouter(sourceBucket string) http.Handler {
 func main() {
 	flag.Parse()
 
+	var handler slog.Handler
+	switch *logFormat {
+	case "text":
+		handler = slog.NewTextHandler(os.Stderr, nil)
+	case "json":
+		handler = slog.NewJSONHandler(os.Stderr, nil)
+	default:
+		fmt.Fprintf(os.Stderr, "invalid -log-format: %q (want text or json)\n", *logFormat)
+		os.Exit(1)
+	}
+	slog.SetDefault(slog.New(handler))
+
 	if *spa && *defaultIndex == "" {
-		log.Fatal("-spa requires -i to be set")
+		fatal("-spa requires -i to be set")
 	}
 	if *spa && *notFoundPath != "" {
-		log.Fatal("-spa and -not-found are mutually exclusive")
+		fatal("-spa and -not-found are mutually exclusive")
 	}
 
 	ctx := context.Background()
@@ -234,18 +249,23 @@ func main() {
 			Scopes:          []string{storage.ScopeFullControl},
 		})
 		if err != nil {
-			log.Fatalf("Failed to load credentials: %v", err)
+			fatal("failed to load credentials", "err", err)
 		}
 		opts = append(opts, option.WithAuthCredentials(creds))
 	}
 	var err error
 	client, err = storage.NewClient(ctx, opts...)
 	if err != nil {
-		log.Fatalf("Failed to create client: %v", err)
+		fatal("failed to create client", "err", err)
 	}
 
-	log.Printf("[service] listening on %s", *bind)
+	slog.Info("listening", "bind", *bind)
 	if err := http.ListenAndServe(*bind, newRouter(*sourceBucket)); err != nil {
-		log.Fatal(err)
+		fatal("server exited", "err", err)
 	}
+}
+
+func fatal(msg string, args ...any) {
+	slog.Error(msg, args...)
+	os.Exit(1)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -609,5 +612,92 @@ func TestProxy_NotFound_MissingPageFallsBackToDefault404(t *testing.T) {
 
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+// --- structured logging tests ---
+
+// installLogger redirects slog.Default() to the given handler for the test
+// duration, restoring the previous default on cleanup.
+func installLogger(t *testing.T, h slog.Handler) {
+	t.Helper()
+	prev := slog.Default()
+	slog.SetDefault(slog.New(h))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+}
+
+func setVerbose(t *testing.T, enabled bool) {
+	t.Helper()
+	prev := *verbose
+	*verbose = enabled
+	t.Cleanup(func() { *verbose = prev })
+}
+
+func TestAccessLog_JSONFormat(t *testing.T) {
+	srv := newTestServer(t, []fakestorage.Object{{
+		ObjectAttrs: fakestorage.ObjectAttrs{BucketName: testBucket, Name: testObject, ContentType: testCType},
+		Content:     []byte(testContent),
+	}})
+	installTestClient(t, srv, "")
+	setVerbose(t, true)
+
+	var buf bytes.Buffer
+	installLogger(t, slog.NewJSONHandler(&buf, nil))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/"+testBucket+"/"+testObject, nil)
+	newRouter("").ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	// Verify the access log was emitted as a single JSON line with the
+	// expected structured fields.
+	logLine := strings.TrimSpace(buf.String())
+	if logLine == "" {
+		t.Fatal("no log output captured")
+	}
+	var entry map[string]any
+	if err := json.Unmarshal([]byte(logLine), &entry); err != nil {
+		t.Fatalf("log output is not valid JSON: %v\nraw: %s", err, logLine)
+	}
+	if got := entry["msg"]; got != "access" {
+		t.Errorf("msg = %v, want %q", got, "access")
+	}
+	if got := entry["method"]; got != "GET" {
+		t.Errorf("method = %v, want %q", got, "GET")
+	}
+	if got := entry["status"]; got != float64(http.StatusOK) { // json numbers are float64
+		t.Errorf("status = %v, want %d", got, http.StatusOK)
+	}
+	if got, ok := entry["url"].(string); !ok || !strings.HasSuffix(got, testObject) {
+		t.Errorf("url = %v, want suffix %q", entry["url"], testObject)
+	}
+	if _, ok := entry["elapsed"].(float64); !ok {
+		t.Errorf("elapsed is missing or not a number: %v", entry["elapsed"])
+	}
+}
+
+func TestAccessLog_NotEmittedWithoutVerbose(t *testing.T) {
+	srv := newTestServer(t, []fakestorage.Object{{
+		ObjectAttrs: fakestorage.ObjectAttrs{BucketName: testBucket, Name: testObject, ContentType: testCType},
+		Content:     []byte(testContent),
+	}})
+	installTestClient(t, srv, "")
+	setVerbose(t, false)
+
+	var buf bytes.Buffer
+	installLogger(t, slog.NewJSONHandler(&buf, nil))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/"+testBucket+"/"+testObject, nil)
+	newRouter("").ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got := strings.TrimSpace(buf.String()); got != "" {
+		t.Errorf("unexpected log output without -v: %q", got)
 	}
 }


### PR DESCRIPTION
## Summary

Resolves #39 (requested by @regressEdo): adds JSON logging support, intended for ingestion by Cloud Logging, Datadog, Loki, etc.

- Switches all logging from `log` to `log/slog`.
- Adds `-log-format <text|json>` flag (default `text`).
- Access logs include structured fields: `remote`, `elapsed`, `status`, `method`, `url`.
- Startup / fatal errors also honor the configured format via a small `fatal()` helper.

## Example

```bash
gcsproxy -log-format json -v
```

```json
{"time":"2026-05-21T09:00:00Z","level":"INFO","msg":"listening","bind":"127.0.0.1:8080"}
{"time":"2026-05-21T09:00:04Z","level":"INFO","msg":"access","remote":"127.0.0.1","elapsed":0.0042,"status":200,"method":"GET","url":"/bucket/foo/bar"}
```

## Breaking change (minor)

The text-mode output format changes:

| | Before | After |
|---|---|---|
| Startup | `2026/05/21 09:00:00 [service] listening on 127.0.0.1:8080` | `time=2026-05-21T09:00:00 level=INFO msg=listening bind=127.0.0.1:8080` |
| Access | `[127.0.0.1] 0.004 200 GET /bucket/foo/bar` | `time=2026-05-21T09:00:04 level=INFO msg=access remote=127.0.0.1 elapsed=0.004 status=200 method=GET url=/bucket/foo/bar` |

Operators with regex/grep on the old format will need to adjust. Logged in the README under the new `### Logging` section.

## Test plan

- [x] `go test -race -count=1 ./...` passes locally (29 tests; +2 new)
- [x] `go vet ./...` / `go build ./...` pass
- [x] Smoke test: invalid `-log-format` fatally exits with clear message; `-spa` validation errors render correctly in both text and json modes
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)