### PR TITLE
feat: switch defaults for cloud-native deployment (chunked + JSON logs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ gcsproxy lets you keep a GCS bucket private while still serving its objects over
 ## Features
 
 - Streams GCS objects directly to clients (no temporary files on disk)
-- Forwards `Content-Type`, `Content-Language`, `Cache-Control`, `Content-Disposition`, `Content-Encoding`, `Content-Length`, `Last-Modified`
+- Forwards `Content-Type`, `Content-Language`, `Cache-Control`, `Content-Disposition`, `Content-Encoding`, `Last-Modified` (and `Content-Length` with `-content-length`)
 - Honors `If-Modified-Since` and replies `304 Not Modified` when appropriate
 - Negotiates `Content-Encoding: gzip` when the client accepts it
 - Optional default index file (`-i`) for serving static sites
@@ -57,10 +57,12 @@ Usage of gcsproxy:
         The path to the keyfile. If not present, client will use your default application credentials.
   -bucket string
         Fixed bucket name. If unset, the bucket is taken from the first path segment.
+  -content-length
+        Send the Content-Length header. By default it is omitted so responses use Transfer-Encoding: chunked, which avoids platform response-size limits (e.g. Cloud Run's 32 MiB cap).
   -i string
         The default index file to serve.
   -log-format string
-        Log output format: text or json. (default "text")
+        Log output format: text or json. (default "json")
   -not-found string
         Object path served with HTTP 404 when no object matches the request. Mutually exclusive with -spa.
   -spa
@@ -123,17 +125,25 @@ GET /test-bucket/missing
 
 ### Logging
 
-gcsproxy uses Go's standard `log/slog` package and writes structured logs to stderr. The `-log-format` flag selects the output encoding:
-
-```
-gcsproxy -log-format json -v
-```
+gcsproxy uses Go's standard `log/slog` package and writes structured logs to stderr. The default `json` format is ready to be ingested by Cloud Logging, Datadog, Loki, and similar aggregation pipelines:
 
 ```json
 {"time":"2026-05-21T09:00:00Z","level":"INFO","msg":"access","remote":"127.0.0.1","elapsed":0.0042,"status":200,"method":"GET","url":"/bucket/foo/bar"}
 ```
 
-The default (`text`) is human-readable `key=value` output. JSON mode is intended for log aggregation pipelines like Cloud Logging, Datadog, or Loki. The access log line is only emitted when `-v` is set.
+Pass `-log-format text` for human-readable `key=value` output when running locally:
+
+```
+gcsproxy -log-format text -v
+```
+
+The access log line is only emitted when `-v` is set.
+
+### Transfer encoding
+
+By default gcsproxy does not emit the `Content-Length` header. `net/http` then uses `Transfer-Encoding: chunked` for any response large enough to matter — which is what platforms like Cloud Run need to bypass their [32 MiB non-streamed response cap](https://cloud.google.com/run/quotas). Small responses may still get an auto-populated `Content-Length` from `net/http`, but that is harmless because they are well below any platform limit.
+
+Pass `-content-length` to opt back into emitting the header for every response, e.g. when clients need to know the total size up front for progress indicators. With this flag, the 32 MiB Cloud Run cap will apply.
 
 ### Health check
 

--- a/main.go
+++ b/main.go
@@ -21,13 +21,14 @@ import (
 )
 
 type Server struct {
-	addr         string
-	client       *storage.Client
-	defaultIndex string
-	sourceBucket string
-	spa          bool
-	notFoundPath string
-	verbose      bool
+	addr          string
+	client        *storage.Client
+	defaultIndex  string
+	sourceBucket  string
+	spa           bool
+	notFoundPath  string
+	contentLength bool
+	verbose       bool
 }
 
 func main() {
@@ -39,7 +40,8 @@ func main() {
 		sourceBucket    = flag.String("bucket", "", "Fixed bucket name. If unset, the bucket is taken from the first path segment.")
 		spa             = flag.Bool("spa", false, "Single-page application fallback. When a request does not match an object, serve the -i index file from the bucket root with HTTP 200. Requires -i; mutually exclusive with -not-found.")
 		notFoundPath    = flag.String("not-found", "", "Object path served with HTTP 404 when no object matches the request. Mutually exclusive with -spa.")
-		logFormat       = flag.String("log-format", "text", "Log output format: text or json.")
+		logFormat       = flag.String("log-format", "json", "Log output format: text or json.")
+		contentLength   = flag.Bool("content-length", false, "Send the Content-Length header. By default it is omitted so responses use Transfer-Encoding: chunked, which avoids platform response-size limits (e.g. Cloud Run's 32 MiB cap).")
 	)
 	flag.Parse()
 
@@ -80,13 +82,14 @@ func main() {
 	}
 
 	s := &Server{
-		addr:         *bind,
-		client:       client,
-		defaultIndex: *defaultIndex,
-		sourceBucket: *sourceBucket,
-		spa:          *spa,
-		notFoundPath: *notFoundPath,
-		verbose:      *verbose,
+		addr:          *bind,
+		client:        client,
+		defaultIndex:  *defaultIndex,
+		sourceBucket:  *sourceBucket,
+		spa:           *spa,
+		notFoundPath:  *notFoundPath,
+		contentLength: *contentLength,
+		verbose:       *verbose,
 	}
 
 	if err := s.ListenAndServe(); err != nil {
@@ -221,7 +224,9 @@ func (s *Server) streamObject(w http.ResponseWriter, r *http.Request, attrs *sto
 	setStrHeader(w, "Cache-Control", attrs.CacheControl)
 	setStrHeader(w, "Content-Encoding", objr.Attrs.ContentEncoding)
 	setStrHeader(w, "Content-Disposition", attrs.ContentDisposition)
-	setIntHeader(w, "Content-Length", objr.Attrs.Size)
+	if s.contentLength {
+		setIntHeader(w, "Content-Length", objr.Attrs.Size)
+	}
 	w.WriteHeader(status)
 	io.Copy(w, objr)
 	return nil

--- a/main_test.go
+++ b/main_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -660,5 +661,49 @@ func TestAccessLog_NotEmittedWithoutVerbose(t *testing.T) {
 	}
 	if got := strings.TrimSpace(buf.String()); got != "" {
 		t.Errorf("unexpected log output without -v: %q", got)
+	}
+}
+
+// --- Content-Length / chunked transfer tests ---
+
+func TestProxy_DefaultDoesNotSetContentLength(t *testing.T) {
+	// By default the handler must not emit a Content-Length header itself.
+	// net/http may still auto-fill it for small bodies that fit in its
+	// internal buffer, but for anything large enough to matter (e.g. the
+	// Cloud Run 32 MiB limit) net/http will fall back to chunked encoding.
+	s := newTestServer(t, []fakestorage.Object{{
+		ObjectAttrs: fakestorage.ObjectAttrs{BucketName: testBucket, Name: testObject, ContentType: testCType},
+		Content:     []byte(testContent),
+	}})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/"+testBucket+"/"+testObject, nil)
+	s.handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got := rec.Header().Get("Content-Length"); got != "" {
+		t.Errorf("Content-Length should not be set by the handler, got %q", got)
+	}
+}
+
+func TestProxy_ContentLengthOptIn(t *testing.T) {
+	s := newTestServer(t, []fakestorage.Object{{
+		ObjectAttrs: fakestorage.ObjectAttrs{BucketName: testBucket, Name: testObject, ContentType: testCType},
+		Content:     []byte(testContent),
+	}})
+	s.contentLength = true
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/"+testBucket+"/"+testObject, nil)
+	s.handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	wantLen := strconv.Itoa(len(testContent))
+	if got := rec.Header().Get("Content-Length"); got != wantLen {
+		t.Errorf("Content-Length = %q, want %q", got, wantLen)
 	}
 }


### PR DESCRIPTION
## Summary

Two related default changes for the dominant gcsproxy deployment profile (Cloud Run / GKE / containerized runtimes).

### 1. \`Content-Length\` no longer emitted by default — resolves #33

Previously the handler always set \`Content-Length\` to the GCS object's size. On Cloud Run this caused responses larger than [the 32 MiB non-streamed payload cap](https://cloud.google.com/run/quotas) to be rejected by the platform, blocking the use case in #33 (by @ManuelLR).

With the header omitted, \`net/http\` uses \`Transfer-Encoding: chunked\` for any body large enough to matter. Small bodies may still get an auto-populated \`Content-Length\` (Go optimization), but that is harmless because they are well below any platform limit.

A new \`-content-length\` flag opts back into emitting the header for every response — useful when clients need the total size up front (e.g. for progress indicators), at the cost of platform size limits applying.

### 2. \`-log-format\` now defaults to \`json\`

Cloud Logging / Datadog / Loki / etc. parse JSON logs natively and surface structured fields (severity, trace, etc.). The previous \`text\` default produced \`time=... level=INFO ...\` slog text encoding, which is no longer the historical bracket-prefixed format anyway (that broke when we moved to \`log/slog\` in #48), so this is a small additional change.

\`-log-format text\` still works for local development.

## Test plan

- [x] \`go test -race -count=1 ./...\` passes (35 tests, +2 new)
- [x] \`go vet ./...\` / \`go build ./...\` pass
- [x] Smoke test: \`gcsproxy -h\` shows \`(default "json")\` for \`-log-format\`; \`-content-length\` flag documented
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)