### PR TITLE
feat: add -cors-origin for simple CORS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ gcsproxy lets you keep a GCS bucket private while still serving its objects over
 - Optional fixed bucket (`-bucket`) for hosting a single bucket without exposing its name in URLs
 - Optional SPA fallback (`-spa`) that returns the index file with HTTP 200 for unmatched routes
 - Optional custom not-found page (`-not-found`) served with HTTP 404 for unmatched routes
+- Optional `Access-Control-Allow-Origin` header (`-cors-origin`) for simple CORS use cases
 - Structured logging via `log/slog` with text or JSON output (`-log-format`)
 - `/_health` endpoint for liveness/readiness probes
 
@@ -52,22 +53,24 @@ go install github.com/daichirata/gcsproxy@latest
 ```
 Usage of gcsproxy:
   -b string
-        Bind address (default "127.0.0.1:8080")
-  -c string
-        The path to the keyfile. If not present, client will use your default application credentials.
+        Bind address. (default "127.0.0.1:8080")
   -bucket string
-        Fixed bucket name. If unset, the bucket is taken from the first path segment.
+        Fixed bucket name. Disables bucket extraction from the path.
+  -c string
+        Path to a service-account key file. Defaults to Application Default Credentials.
   -content-length
-        Send the Content-Length header. By default it is omitted so responses use Transfer-Encoding: chunked, which avoids platform response-size limits (e.g. Cloud Run's 32 MiB cap).
+        Send the Content-Length header (disables chunked transfer).
+  -cors-origin string
+        Value for the Access-Control-Allow-Origin header.
   -i string
-        The default index file to serve.
+        Default index file to serve.
   -log-format string
         Log output format: text or json. (default "json")
   -not-found string
-        Object path served with HTTP 404 when no object matches the request. Mutually exclusive with -spa.
+        Object served with HTTP 404 for unmatched routes.
   -spa
-        Single-page application fallback. When a request does not match an object, serve the -i index file from the bucket root with HTTP 200. Requires -i; mutually exclusive with -not-found.
-  -v    Show access log
+        SPA fallback: serve -i from the bucket root with HTTP 200 for unmatched routes.
+  -v    Show access log.
 ```
 
 ### Routing
@@ -144,6 +147,17 @@ The access log line is only emitted when `-v` is set.
 By default gcsproxy does not emit the `Content-Length` header. `net/http` then uses `Transfer-Encoding: chunked` for any response large enough to matter — which is what platforms like Cloud Run need to bypass their [32 MiB non-streamed response cap](https://cloud.google.com/run/quotas). Small responses may still get an auto-populated `Content-Length` from `net/http`, but that is harmless because they are well below any platform limit.
 
 Pass `-content-length` to opt back into emitting the header for every response, e.g. when clients need to know the total size up front for progress indicators. With this flag, the 32 MiB Cloud Run cap will apply.
+
+### CORS
+
+Pass `-cors-origin <value>` to add an `Access-Control-Allow-Origin` header to every response (success and error alike):
+
+```
+gcsproxy -cors-origin '*'
+gcsproxy -cors-origin 'https://example.com'
+```
+
+This is sufficient for [simple cross-origin requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests) — `<img>`, `<link>`, `<video>`, plain `fetch(url)` etc. — which is what most static-site hosting needs. Requests that require a preflight (custom headers, credentialed `fetch`, non-`GET/HEAD/POST` methods) are not supported; front gcsproxy with a proxy like nginx if you need that.
 
 ### Health check
 

--- a/main.go
+++ b/main.go
@@ -28,20 +28,22 @@ type Server struct {
 	spa           bool
 	notFoundPath  string
 	contentLength bool
+	corsOrigin    string
 	verbose       bool
 }
 
 func main() {
 	var (
-		bind            = flag.String("b", "127.0.0.1:8080", "Bind address")
-		verbose         = flag.Bool("v", false, "Show access log")
-		credentialsFile = flag.String("c", "", "The path to the keyfile. If not present, client will use your default application credentials.")
-		defaultIndex    = flag.String("i", "", "The default index file to serve.")
-		sourceBucket    = flag.String("bucket", "", "Fixed bucket name. If unset, the bucket is taken from the first path segment.")
-		spa             = flag.Bool("spa", false, "Single-page application fallback. When a request does not match an object, serve the -i index file from the bucket root with HTTP 200. Requires -i; mutually exclusive with -not-found.")
-		notFoundPath    = flag.String("not-found", "", "Object path served with HTTP 404 when no object matches the request. Mutually exclusive with -spa.")
+		bind            = flag.String("b", "127.0.0.1:8080", "Bind address.")
+		verbose         = flag.Bool("v", false, "Show access log.")
+		credentialsFile = flag.String("c", "", "Path to a service-account key file. Defaults to Application Default Credentials.")
+		defaultIndex    = flag.String("i", "", "Default index file to serve.")
+		sourceBucket    = flag.String("bucket", "", "Fixed bucket name. Disables bucket extraction from the path.")
+		spa             = flag.Bool("spa", false, "SPA fallback: serve -i from the bucket root with HTTP 200 for unmatched routes.")
+		notFoundPath    = flag.String("not-found", "", "Object served with HTTP 404 for unmatched routes.")
 		logFormat       = flag.String("log-format", "json", "Log output format: text or json.")
-		contentLength   = flag.Bool("content-length", false, "Send the Content-Length header. By default it is omitted so responses use Transfer-Encoding: chunked, which avoids platform response-size limits (e.g. Cloud Run's 32 MiB cap).")
+		contentLength   = flag.Bool("content-length", false, "Send the Content-Length header (disables chunked transfer).")
+		corsOrigin      = flag.String("cors-origin", "", "Value for the Access-Control-Allow-Origin header.")
 	)
 	flag.Parse()
 
@@ -89,6 +91,7 @@ func main() {
 		spa:           *spa,
 		notFoundPath:  *notFoundPath,
 		contentLength: *contentLength,
+		corsOrigin:    *corsOrigin,
 		verbose:       *verbose,
 	}
 
@@ -122,6 +125,9 @@ func (s *Server) handler() http.Handler {
 func (s *Server) wrap(fn http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		proc := time.Now()
+		if s.corsOrigin != "" {
+			w.Header().Set("Access-Control-Allow-Origin", s.corsOrigin)
+		}
 		writer := &wrapResponseWriter{
 			ResponseWriter: w,
 			status:         http.StatusOK,

--- a/main_test.go
+++ b/main_test.go
@@ -707,3 +707,57 @@ func TestProxy_ContentLengthOptIn(t *testing.T) {
 		t.Errorf("Content-Length = %q, want %q", got, wantLen)
 	}
 }
+
+// --- CORS tests ---
+
+func TestProxy_CORSOrigin_Set(t *testing.T) {
+	s := newTestServer(t, []fakestorage.Object{{
+		ObjectAttrs: fakestorage.ObjectAttrs{BucketName: testBucket, Name: testObject, ContentType: testCType},
+		Content:     []byte(testContent),
+	}})
+	s.corsOrigin = "https://example.com"
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/"+testBucket+"/"+testObject, nil)
+	s.handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "https://example.com" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want %q", got, "https://example.com")
+	}
+}
+
+func TestProxy_CORSOrigin_AppliesToErrorResponses(t *testing.T) {
+	// CORS header must be present even on 404 so the browser surfaces the
+	// real status to JS instead of treating it as an opaque CORS failure.
+	s := newTestServer(t, nil)
+	s.corsOrigin = "*"
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/"+testBucket+"/missing", nil)
+	s.handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want %q", got, "*")
+	}
+}
+
+func TestProxy_CORSOrigin_Unset(t *testing.T) {
+	s := newTestServer(t, []fakestorage.Object{{
+		ObjectAttrs: fakestorage.ObjectAttrs{BucketName: testBucket, Name: testObject, ContentType: testCType},
+		Content:     []byte(testContent),
+	}})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/"+testBucket+"/"+testObject, nil)
+	s.handler().ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("Access-Control-Allow-Origin should be unset, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds simple CORS support for static-site hosting use cases, plus a small flag-help cleanup.

### \`-cors-origin <value>\`

When set, every response carries an \`Access-Control-Allow-Origin\` header with the given value (both success and error responses, so browsers surface real statuses to JS):

\`\`\`bash
gcsproxy -cors-origin '*'
gcsproxy -cors-origin 'https://example.com'
\`\`\`

This is sufficient for [simple cross-origin requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests) — \`<img>\`, \`<link>\`, \`<video>\`, plain \`fetch(url)\` without custom headers or credentials. That covers the vast majority of static-site hosting needs.

Preflight (OPTIONS) is intentionally not implemented — requests that need a preflight (custom headers, credentialed \`fetch\`, non-\`GET/HEAD/POST\` methods) should be handled by an upstream proxy. The README notes this in the new \`### CORS\` section.

### Flag help cleanup

Every flag's help string was shortened to a single concise line. Details that used to be in the help string now live in the README sections that already describe each feature. The \`-h\` output is much easier to scan now.

## Test plan

- [x] \`go test -race -count=1 ./...\` passes (38 tests, +3 new)
- [x] \`go vet ./...\` / \`go build ./...\` pass
- [x] Smoke test: \`-cors-origin '*'\` sets the header on success and on 404
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)