### PR TITLE
docs: add status badges and a Quick start section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # gcsproxy
 
+[![Test](https://github.com/daichirata/gcsproxy/actions/workflows/test.yaml/badge.svg)](https://github.com/daichirata/gcsproxy/actions/workflows/test.yaml)
+[![Release](https://img.shields.io/github/v/release/daichirata/gcsproxy)](https://github.com/daichirata/gcsproxy/releases/latest)
+[![Go](https://img.shields.io/github/go-mod/go-version/daichirata/gcsproxy)](go.mod)
+[![License](https://img.shields.io/github/license/daichirata/gcsproxy)](LICENSE)
+
 A lightweight reverse proxy for Google Cloud Storage.
 
 gcsproxy lets you keep a GCS bucket private while still serving its objects over HTTP, so you can put your own access controls (IP allowlist, basic auth, IAP, etc.) in front of it. It authenticates to GCS using the host's credentials and streams object contents back to the client.
@@ -10,6 +15,23 @@ gcsproxy lets you keep a GCS bucket private while still serving its objects over
 |  (auth / IP allow / TLS)    | ------> |  gcsproxy  | ------> |   Google Cloud   |
 |                             |         |            |   API   |     Storage      |
 +-----------------------------+         +------------+         +------------------+
+```
+
+## Quick start
+
+Run gcsproxy locally with your existing [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials) (set up via `gcloud auth application-default login`):
+
+```bash
+docker run --rm -p 8080:80 \
+    -e GOOGLE_APPLICATION_CREDENTIALS=/cred.json \
+    -v ~/.config/gcloud/application_default_credentials.json:/cred.json \
+    ghcr.io/daichirata/gcsproxy:latest -b 0.0.0.0:80
+```
+
+Then fetch a private object through the proxy:
+
+```bash
+curl http://localhost:8080/<your-bucket>/<your-object>
 ```
 
 ## Features


### PR DESCRIPTION
## Summary

Visual polish for the README top half — no functional changes.

- **Status badges** under the title: test workflow, latest release, Go version, license. The repo's state is now visible at a glance.
- **Quick start** section directly after the architecture diagram. A single Docker one-liner that reuses the reader's existing Application Default Credentials lets them verify gcsproxy works in 30 seconds before scrolling through Features / Installation / Usage.

## Preview

```markdown
# gcsproxy

[Test ✓] [Release v0.4.4] [Go 1.25] [License MIT]

A lightweight reverse proxy for Google Cloud Storage.
... description ...
... ASCII diagram ...

## Quick start

docker run --rm -p 8080:80 \
    -e GOOGLE_APPLICATION_CREDENTIALS=/cred.json \
    -v ~/.config/gcloud/application_default_credentials.json:/cred.json \
    ghcr.io/daichirata/gcsproxy:latest -b 0.0.0.0:80

curl http://localhost:8080/<your-bucket>/<your-object>
```

## Test plan

- [x] No code changes; existing tests unaffected
- [x] Badge URLs follow GitHub / shields.io conventions; will resolve once the PR is merged and rendered on master

🤖 Generated with [Claude Code](https://claude.com/claude-code)