### PR TITLE
chore(ci): bump actions to Node 24-ready versions and pin goreleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,23 +8,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25'
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
-          version: latest
+          version: '~> v2'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25'
       - name: Verify go.mod is tidy


### PR DESCRIPTION
## Summary

The v0.5.0 release workflow run printed two warnings:

1. **Node.js 20 deprecation.** GitHub Actions removes Node.js 20 from the runner on 2026-09-16 and forces Node.js 24 as the default on 2026-06-02. The third-party actions in our workflows still ran on Node.js 20.
2. **goreleaser \`version: latest\`.** Floats with upstream; a future goreleaser major release could silently break the release pipeline.

Both addressed here.

## Changes

| Action | Before | After | Why |
|---|---|---|---|
| actions/checkout | v4 | v6 | v6.0.0+ uses \`node24\` |
| actions/setup-go | v5 | v6 | v6.0.0+ uses \`node24\` |
| docker/login-action | v3 | v4 | v4.0.0+ uses \`node24\` |
| goreleaser/goreleaser-action | v6 | v7 | v7.0.0+ uses \`node24\` |
| goreleaser binary (\`with: version\`) | \`latest\` | \`'~> v2'\` | Pin to current major |

Each target version was verified by reading its \`action.yml\` and confirming \`runs.using: node24\`.

## Test plan

- [x] No code or behavior changes; workflow updates only
- [ ] CI green on this PR (test workflow exercises checkout/setup-go on the new majors)
- [ ] Next release (\`v0.5.1\` or beyond) verifies the release workflow chain end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)