### PR TITLE
feat: add -log-level flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Usage of gcsproxy:
         Default index file to serve.
   -log-format string
         Log output format: text or json. (default "json")
+  -log-level string
+        Minimum log level: debug, info, warn, or error. (default "info")
   -not-found string
         Object served with HTTP 404 for unmatched routes.
   -spa
@@ -164,6 +166,12 @@ gcsproxy -log-format text -v
 ```
 
 The access log line is only emitted when `-v` is set.
+
+`-log-level <debug|info|warn|error>` (default `info`) filters at the slog handler. Set it to `warn` to suppress the `INFO` startup and access logs while keeping `WARN`/`ERROR` visible:
+
+```
+gcsproxy -log-level warn
+```
 
 ### Transfer encoding
 

--- a/main.go
+++ b/main.go
@@ -42,17 +42,24 @@ func main() {
 		spa             = flag.Bool("spa", false, "SPA fallback: serve -i from the bucket root with HTTP 200 for unmatched routes.")
 		notFoundPath    = flag.String("not-found", "", "Object served with HTTP 404 for unmatched routes.")
 		logFormat       = flag.String("log-format", "json", "Log output format: text or json.")
+		logLevel        = flag.String("log-level", "info", "Minimum log level: debug, info, warn, or error.")
 		contentLength   = flag.Bool("content-length", false, "Send the Content-Length header (disables chunked transfer).")
 		corsOrigin      = flag.String("cors-origin", "", "Value for the Access-Control-Allow-Origin header.")
 	)
 	flag.Parse()
 
+	level, err := parseLogLevel(*logLevel)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	handlerOpts := &slog.HandlerOptions{Level: level}
 	var handler slog.Handler
 	switch *logFormat {
 	case "text":
-		handler = slog.NewTextHandler(os.Stderr, nil)
+		handler = slog.NewTextHandler(os.Stderr, handlerOpts)
 	case "json":
-		handler = slog.NewJSONHandler(os.Stderr, nil)
+		handler = slog.NewJSONHandler(os.Stderr, handlerOpts)
 	default:
 		fmt.Fprintf(os.Stderr, "invalid -log-format: %q (want text or json)\n", *logFormat)
 		os.Exit(1)
@@ -417,4 +424,18 @@ func (w *wrapResponseWriter) WriteHeader(status int) {
 func fatal(msg string, args ...any) {
 	slog.Error(msg, args...)
 	os.Exit(1)
+}
+
+func parseLogLevel(s string) (slog.Level, error) {
+	switch strings.ToLower(s) {
+	case "debug":
+		return slog.LevelDebug, nil
+	case "info":
+		return slog.LevelInfo, nil
+	case "warn":
+		return slog.LevelWarn, nil
+	case "error":
+		return slog.LevelError, nil
+	}
+	return 0, fmt.Errorf("invalid -log-level: %q (want debug, info, warn, or error)", s)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1104,3 +1104,71 @@ func TestProxy_Range_ForwardsContentEncoding(t *testing.T) {
 		t.Errorf("Content-Encoding = %q, want %q", got, "br")
 	}
 }
+
+// --- Log level tests ---
+
+func TestParseLogLevel(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    slog.Level
+		wantErr bool
+	}{
+		{"debug", slog.LevelDebug, false},
+		{"info", slog.LevelInfo, false},
+		{"warn", slog.LevelWarn, false},
+		{"error", slog.LevelError, false},
+		{"DEBUG", slog.LevelDebug, false}, // case-insensitive
+		{"Info", slog.LevelInfo, false},
+		{"WARN", slog.LevelWarn, false},
+		{"", 0, true},
+		{"trace", 0, true},
+		{"notice", 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := parseLogLevel(tc.in)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tc.wantErr)
+			}
+			if err == nil && got != tc.want {
+				t.Errorf("level = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAccessLog_SuppressedByLogLevel(t *testing.T) {
+	// Even with -v on, an access log at INFO is filtered out when the
+	// handler level is WARN.
+	s := newTestServer(t, []fakestorage.Object{{
+		ObjectAttrs: fakestorage.ObjectAttrs{BucketName: testBucket, Name: testObject, ContentType: testCType},
+		Content:     []byte(testContent),
+	}})
+	s.verbose = true
+
+	var buf bytes.Buffer
+	installLogger(t, slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/"+testBucket+"/"+testObject, nil)
+	s.handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got := strings.TrimSpace(buf.String()); got != "" {
+		t.Errorf("INFO access log should be filtered at WARN, got %q", got)
+	}
+}
+
+func TestWarnLog_PassesThroughWarnLevel(t *testing.T) {
+	// A slog.Warn call should still appear when the handler level is WARN.
+	var buf bytes.Buffer
+	installLogger(t, slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	slog.Warn("smoke", "key", "value")
+
+	if got := buf.String(); !strings.Contains(got, `"level":"WARN"`) || !strings.Contains(got, `"msg":"smoke"`) {
+		t.Errorf("warn log was not emitted at WARN level, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Resolves #54 (requested by @regressEdo). Adds a \`-log-level\` flag so the log volume can be tuned without dropping JSON output:

\`\`\`
gcsproxy -log-format json -log-level warn
\`\`\`

Accepted values: \`debug\`, \`info\` (default), \`warn\`, \`error\`. Case-insensitive. The flag is wired into \`slog.HandlerOptions.Level\`, so it acts as a single filter for every log call (startup, access, warnings, fatal).

## Behavior matrix

| `-log-level` | `listening` (INFO) | `access` (INFO, gated by `-v`) | If-Modified-Since parse error (WARN) | fatal errors (ERROR) |
|---|---|---|---|---|
| `debug` | ✅ | ✅ | ✅ | ✅ |
| `info` (default) | ✅ | ✅ | ✅ | ✅ |
| `warn` | — | — | ✅ | ✅ |
| `error` | — | — | — | ✅ |

Existing behavior is preserved since `info` is the default.

## Test plan

- [x] \`go test -race -count=1 ./...\` passes (table-driven parser tests + integration check that an INFO access log is filtered at WARN)
- [x] \`go vet ./...\` / \`go build ./...\` pass
- [x] Smoke test: invalid value (\`-log-level=foo\`) prints a clear message and exits 1; \`-h\` lists the new flag
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)