### PR TITLE
chore: drop legacy Dockerfile, rename Dockerfile.goreleaser to Dockerfile

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -54,7 +54,7 @@ dockers:
     use: buildx
     goos: linux
     goarch: amd64
-    dockerfile: Dockerfile.goreleaser
+    dockerfile: Dockerfile
     build_flag_templates:
       - "--platform=linux/amd64"
   - image_templates:
@@ -62,7 +62,7 @@ dockers:
     use: buildx
     goos: linux
     goarch: arm64
-    dockerfile: Dockerfile.goreleaser
+    dockerfile: Dockerfile
     build_flag_templates:
       - "--platform=linux/arm64"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,4 @@
-FROM debian:buster-slim AS build
-
-WORKDIR /tmp
-ARG GCSPROXY_VERSION=0.4.2
-
-RUN apt-get update \
-    && apt-get install --no-install-suggests --no-install-recommends --yes ca-certificates wget \
-    && wget https://github.com/daichirata/gcsproxy/releases/download/v${GCSPROXY_VERSION}/gcsproxy-${GCSPROXY_VERSION}-linux-amd64.tar.gz \
-    && tar zxf gcsproxy-${GCSPROXY_VERSION}-linux-amd64.tar.gz \
-    && cp ./gcsproxy-${GCSPROXY_VERSION}-linux-amd64/gcsproxy .
-
 FROM gcr.io/distroless/base
-COPY --from=build /tmp/gcsproxy /gcsproxy
+COPY gcsproxy /gcsproxy
 ENTRYPOINT ["/gcsproxy"]
 CMD [ "-b", "0.0.0.0:80" ]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,4 +1,0 @@
-FROM gcr.io/distroless/base
-COPY gcsproxy /gcsproxy
-ENTRYPOINT ["/gcsproxy"]
-CMD [ "-b", "0.0.0.0:80" ]


### PR DESCRIPTION
## Summary

The repo carried two Dockerfiles. This PR consolidates them.

| Before | After |
|---|---|
| \`Dockerfile\` — multi-stage debian builder that \`wget\`s the v0.4.2 release tarball into a distroless final stage. Amd64-only, version pinned to a very old release. | (deleted) |
| \`Dockerfile.goreleaser\` — four-line distroless image used by the release pipeline. | renamed to \`Dockerfile\` |

The legacy build approach is fully covered by the multi-arch images published to \`ghcr.io/daichirata/gcsproxy\` on every release (#44), so the standalone download-and-package Dockerfile no longer pays for itself.

\`.goreleaser.yml\` references updated accordingly. \`goreleaser check\` still passes.

## Test plan

- [x] \`goreleaser check\` passes
- [x] Final \`Dockerfile\` is the same four-line distroless image goreleaser was already using
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)