### PR TITLE
feat: add optional walk-up index compatibility mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Usage of gcsproxy:
   -spa
         SPA fallback: serve -i from the bucket root with HTTP 200 for unmatched routes.
   -v    Show access log.
+  -walk-up-index
+        When -i lookup misses, retry parent directories for index files before not-found handling.
 ```
 
 ### Routing
@@ -125,6 +127,16 @@ gcsproxy -i index.html
 
 GET /test-bucket/foo/bar
   -> gs://test-bucket/foo/bar/index.html
+```
+
+When `-walk-up-index` is also set, gcsproxy will retry parent directories while keeping the same bucket/object prefix:
+
+```
+gcsproxy -i index.html -walk-up-index
+
+GET /test-bucket/prefix/site/search
+  -> try gs://test-bucket/prefix/site/search/index.html
+  -> try gs://test-bucket/prefix/site/index.html
 ```
 
 ### SPA fallback

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ type Server struct {
 	addr          string
 	client        *storage.Client
 	defaultIndex  string
+	walkUpIndex   bool
 	sourceBucket  string
 	spa           bool
 	notFoundPath  string
@@ -38,6 +39,7 @@ func main() {
 		verbose         = flag.Bool("v", false, "Show access log.")
 		credentialsFile = flag.String("c", "", "Path to a service-account key file. Defaults to Application Default Credentials.")
 		defaultIndex    = flag.String("i", "", "Default index file to serve.")
+		walkUpIndex     = flag.Bool("walk-up-index", false, "When -i lookup misses, retry parent directories for index files before not-found handling.")
 		sourceBucket    = flag.String("bucket", "", "Fixed bucket name. Disables bucket extraction from the path.")
 		spa             = flag.Bool("spa", false, "SPA fallback: serve -i from the bucket root with HTTP 200 for unmatched routes.")
 		notFoundPath    = flag.String("not-found", "", "Object served with HTTP 404 for unmatched routes.")
@@ -94,6 +96,7 @@ func main() {
 		addr:          *bind,
 		client:        client,
 		defaultIndex:  *defaultIndex,
+		walkUpIndex:   *walkUpIndex,
 		sourceBucket:  *sourceBucket,
 		spa:           *spa,
 		notFoundPath:  *notFoundPath,
@@ -211,15 +214,58 @@ func (s *Server) fetchObjectAttrs(ctx context.Context, bucket, object string) (*
 			if s.defaultIndex == "" || indexAppended {
 				return nil, err
 			}
-			object, err = url.JoinPath(object, s.defaultIndex)
-			if err != nil {
-				return nil, err
+			candidates, candidateErr := indexCandidates(object, s.defaultIndex, s.walkUpIndex)
+			if candidateErr != nil {
+				return nil, candidateErr
 			}
-			return s.client.Bucket(bucket).Object(object).Attrs(ctx)
+			for _, candidate := range candidates {
+				attrs, candidateErr := s.client.Bucket(bucket).Object(candidate).Attrs(ctx)
+				if candidateErr == nil {
+					return attrs, nil
+				}
+				if !errors.Is(candidateErr, storage.ErrObjectNotExist) {
+					return nil, candidateErr
+				}
+				err = candidateErr
+			}
+			return nil, err
 		}
 		return nil, err
 	}
 	return attrs, nil
+}
+
+func indexCandidates(object, indexName string, walkUp bool) ([]string, error) {
+	trimmed := strings.TrimSuffix(object, "/")
+	first, err := url.JoinPath(trimmed, indexName)
+	if err != nil {
+		return nil, err
+	}
+	candidates := []string{first}
+	if !walkUp {
+		return candidates, nil
+	}
+
+	ancestor := trimmed
+	for {
+		slash := strings.LastIndex(ancestor, "/")
+		if slash < 0 {
+			break
+		}
+		ancestor = ancestor[:slash]
+		candidate := indexName
+		if ancestor != "" {
+			candidate, err = url.JoinPath(ancestor, indexName)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if candidate != candidates[len(candidates)-1] {
+			candidates = append(candidates, candidate)
+		}
+	}
+
+	return candidates, nil
 }
 
 func (s *Server) serveObject(w http.ResponseWriter, r *http.Request, bucket, object string, status int) error {

--- a/main_test.go
+++ b/main_test.go
@@ -8,6 +8,8 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
 	"strconv"
 	"strings"
 	"testing"
@@ -131,6 +133,62 @@ func TestHealthCheck(t *testing.T) {
 	}
 }
 
+func TestIndexCandidates(t *testing.T) {
+	cases := []struct {
+		name      string
+		object    string
+		indexName string
+		walkUp    bool
+		want      []string
+	}{
+		{
+			name:      "single candidate",
+			object:    "foo/bar",
+			indexName: "index.html",
+			walkUp:    false,
+			want:      []string{"foo/bar/index.html"},
+		},
+		{
+			name:      "walk up path and root",
+			object:    "foo/bar/baz",
+			indexName: "index.html",
+			walkUp:    true,
+			want:      []string{"foo/bar/baz/index.html", "foo/bar/index.html", "foo/index.html"},
+		},
+		{
+			name:      "walk up from trailing slash",
+			object:    "foo/bar/",
+			indexName: "index.html",
+			walkUp:    true,
+			want:      []string{"foo/bar/index.html", "foo/index.html"},
+		},
+		{
+			name:      "single segment walk up is unchanged",
+			object:    "search",
+			indexName: "index.html",
+			walkUp:    true,
+			want:      []string{"search/index.html"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := indexCandidates(tc.object, tc.indexName, tc.walkUp)
+			if err != nil {
+				t.Fatalf("indexCandidates() returned error: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("len(got)=%d len(want)=%d; got=%v want=%v", len(got), len(tc.want), got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("candidates[%d]=%q want %q; got=%v want=%v", i, got[i], tc.want[i], got, tc.want)
+				}
+			}
+		})
+	}
+}
+
 // --- proxy / fetchObjectAttrs integration tests (fake-gcs-server) ---
 
 const (
@@ -159,6 +217,19 @@ func newTestServer(t *testing.T, objects []fakestorage.Object) *Server {
 	c := fakeSrv.Client()
 	t.Cleanup(func() { _ = c.Close() })
 	return &Server{client: c}
+}
+
+func newRewriteProxy(t *testing.T, upstreamURL *url.URL, prefix string) *httptest.Server {
+	t.Helper()
+	rp := httputil.NewSingleHostReverseProxy(upstreamURL)
+	baseDirector := rp.Director
+	rp.Director = func(req *http.Request) {
+		baseDirector(req)
+		req.URL.Path = "/" + testBucket + prefix + req.URL.Path
+		req.URL.RawPath = req.URL.Path
+		req.Host = upstreamURL.Host
+	}
+	return httptest.NewServer(rp)
 }
 
 func TestProxy_OK(t *testing.T) {
@@ -296,6 +367,130 @@ func TestProxy_DefaultIndex_SubdirectoryFallback(t *testing.T) {
 		t.Fatalf("status = %d, want %d (body=%q)", rec.Code, http.StatusOK, rec.Body.String())
 	}
 	if got := rec.Body.String(); got != testIndexBody {
+		t.Errorf("body = %q, want %q", got, testIndexBody)
+	}
+}
+
+func TestProxy_DefaultIndex_WalkUpFallback_Disabled(t *testing.T) {
+	s := newTestServer(t, []fakestorage.Object{{
+		ObjectAttrs: fakestorage.ObjectAttrs{
+			BucketName:  testBucket,
+			Name:        "site-assets-gcsproxy/mainnet-site/index.html",
+			ContentType: "text/html",
+		},
+		Content: []byte(testIndexBody),
+	}})
+	s.defaultIndex = "index.html"
+	s.notFoundPath = "404.html"
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/"+testBucket+"/site-assets-gcsproxy/mainnet-site/search", nil)
+	s.handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d (body=%q)", rec.Code, http.StatusNotFound, rec.Body.String())
+	}
+}
+
+func TestProxy_DefaultIndex_WalkUpFallback_Enabled(t *testing.T) {
+	s := newTestServer(t, []fakestorage.Object{{
+		ObjectAttrs: fakestorage.ObjectAttrs{
+			BucketName:  testBucket,
+			Name:        "site-assets-gcsproxy/mainnet-site/index.html",
+			ContentType: "text/html",
+		},
+		Content: []byte(testIndexBody),
+	}})
+	s.defaultIndex = "index.html"
+	s.walkUpIndex = true
+	s.notFoundPath = "404.html"
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/"+testBucket+"/site-assets-gcsproxy/mainnet-site/search", nil)
+	s.handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body=%q)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != testIndexBody {
+		t.Errorf("body = %q, want %q", got, testIndexBody)
+	}
+}
+
+func TestE2E_PrefixRewrite_SearchRouteWithoutWalkUp(t *testing.T) {
+	s := newTestServer(t, []fakestorage.Object{{
+		ObjectAttrs: fakestorage.ObjectAttrs{
+			BucketName:  testBucket,
+			Name:        "site-assets-gcsproxy/mainnet-site/index.html",
+			ContentType: "text/html",
+		},
+		Content: []byte(testIndexBody),
+	}})
+	s.defaultIndex = "index.html"
+	s.notFoundPath = "404.html"
+
+	gcsproxyHTTP := httptest.NewServer(s.handler())
+	t.Cleanup(gcsproxyHTTP.Close)
+	upstreamURL, err := url.Parse(gcsproxyHTTP.URL)
+	if err != nil {
+		t.Fatalf("url.Parse(gcsproxyHTTP.URL): %v", err)
+	}
+
+	rewriteProxy := newRewriteProxy(t, upstreamURL, "/site-assets-gcsproxy/mainnet-site")
+	t.Cleanup(rewriteProxy.Close)
+
+	res, err := http.Get(rewriteProxy.URL + "/search?q=test")
+	if err != nil {
+		t.Fatalf("http.Get: %v", err)
+	}
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("io.ReadAll: %v", err)
+	}
+
+	if res.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d (body=%q)", res.StatusCode, http.StatusNotFound, string(body))
+	}
+}
+
+func TestE2E_PrefixRewrite_SearchRouteWithWalkUp(t *testing.T) {
+	s := newTestServer(t, []fakestorage.Object{{
+		ObjectAttrs: fakestorage.ObjectAttrs{
+			BucketName:  testBucket,
+			Name:        "site-assets-gcsproxy/mainnet-site/index.html",
+			ContentType: "text/html",
+		},
+		Content: []byte(testIndexBody),
+	}})
+	s.defaultIndex = "index.html"
+	s.walkUpIndex = true
+	s.notFoundPath = "404.html"
+
+	gcsproxyHTTP := httptest.NewServer(s.handler())
+	t.Cleanup(gcsproxyHTTP.Close)
+	upstreamURL, err := url.Parse(gcsproxyHTTP.URL)
+	if err != nil {
+		t.Fatalf("url.Parse(gcsproxyHTTP.URL): %v", err)
+	}
+
+	rewriteProxy := newRewriteProxy(t, upstreamURL, "/site-assets-gcsproxy/mainnet-site")
+	t.Cleanup(rewriteProxy.Close)
+
+	res, err := http.Get(rewriteProxy.URL + "/search?q=test")
+	if err != nil {
+		t.Fatalf("http.Get: %v", err)
+	}
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("io.ReadAll: %v", err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body=%q)", res.StatusCode, http.StatusOK, string(body))
+	}
+	if got := string(body); got != testIndexBody {
 		t.Errorf("body = %q, want %q", got, testIndexBody)
 	}
 }


### PR DESCRIPTION
## Summary
- add an opt-in `-walk-up-index` mode for deployments that rely on nested prefix rewrites
- preserve existing default behavior when the flag is not set
- add regression coverage for both direct proxy behavior and a stricter HTTP rewrite chain

## Why
Some environments rewrite user-facing paths into nested object prefixes (for example: `/search?q=test` -> `/<bucket>/<prefix>/search`).

With only single-level `-i` fallback, these routes return 404 even when `.../<prefix>/index.html` exists. This patch restores compatibility as an explicit opt-in.

## Behavior
When `-walk-up-index` is enabled and `-i index.html` is set, lookup retries parent directories:
- `foo/bar/search` -> `foo/bar/search/index.html`
- then `foo/bar/index.html`
- then `foo/index.html`

Without the flag, behavior is unchanged.

## Tests
- `TestIndexCandidates`
- `TestProxy_DefaultIndex_WalkUpFallback_Disabled`
- `TestProxy_DefaultIndex_WalkUpFallback_Enabled`
- `TestE2E_PrefixRewrite_SearchRouteWithoutWalkUp`
- `TestE2E_PrefixRewrite_SearchRouteWithWalkUp`

Validated locally with:
- `go test -race -count=1 ./...` (run inside `golang:1.26` container)
