### PR TITLE
ci: add zizmor and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      go-dependencies:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns: ["*"]
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,26 +3,36 @@ on:
   push:
     tags:
       - v*
+permissions: {}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   goreleaser:
+    name: GoReleaser
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the GitHub release and upload assets
+      packages: write # push images to ghcr.io
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.26'
+          cache: false # release artifacts must not be built from a restorable cache
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           version: '~> v2'
           args: release --clean

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,4 +1,4 @@
-name: Test
+name: zizmor
 on:
   push:
     branches: [master]
@@ -8,8 +8,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  test:
-    name: Test
+  zizmor:
+    name: Run zizmor
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -18,15 +18,8 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
         with:
-          go-version: '1.26'
-      - name: Verify go.mod is tidy
-        run: |
-          go mod tidy
-          git diff --exit-code go.mod go.sum
-      - name: Vet
-        run: go vet ./...
-      - name: Test
-        run: go test -race -count=1 ./...
+          persona: pedantic
+          advanced-security: false


### PR DESCRIPTION
Add [zizmor](https://github.com/zizmorcore/zizmor) (Static check for GitHub actions) for security-related issues in GitHub actions.
Findings fixed:
1. not SHA-pinned actions: This is a door for supply-chain attacks, which have been happening recently: Attackers getting access to a GitHub action project and re-publishing action versions under existing (mutable) tags. This can be avoided by explicitly SHA-pinning. This is a finding also found by zizmor and dependabot will also follow this convention when suggesting updates.
2. overly broad workflow/job permissions. Reduced to the absolute necessary permissions per job, and no permissions at all per workflow.
3. not persisting Git credentials in checkout action.

Another useful workflow change: concurrency control: abort a workflow run when a new commit on the same ref/branch/tag tiggers a new workflow

Also, this PR adds a dependabot.yml configuration for Go dependencies, GitHub actions and docker, following zizmor best practices (zizmor can also audit dependabot.yml files).