### PR TITLE
ci(docker): use distroless/static base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/base
+FROM gcr.io/distroless/static:latest@sha256:d5f030ca7c5793784e9ea4178a116da360250411d13921a5af27c6cb5a5949bf
 COPY gcsproxy /gcsproxy
 ENTRYPOINT ["/gcsproxy"]
 CMD [ "-b", "0.0.0.0:80" ]


### PR DESCRIPTION
Currently, the distroless/base image contains many things actually not needed by gcsproxy:
1. glibc: The distroless/base image has a full GNU C standard library implementation plus a dynamic linker loader and math libraries and charset conversion libraries, in case a binary program links dynamically against the GNU C library, which gcsproxy _does not_ do. It currently also compiles without CGO, so the executable is fully static without any dynamic dependencies
2. OpenSSL: Go has its own crypto/tls TLS engine and does not make use of a system-wide OpenSSL installation
3. libzstd/libz: Go has its own compression/* packages

The only thing that gcsproxy actually needs from a base image is the CA root certificates for TLS/SSL server cert verification against the GCS API endpoint.

This almost halves the effective image size.

We also now pin the base image to make builds fully reproducible and make all updates deliberate using Dependabot.