### PR TITLE
feat: add ETag and full RFC 9110 conditional request support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ curl http://localhost:8080/<your-bucket>/<your-object>
 
 - Streams GCS objects directly to clients (no temporary files on disk)
 - Forwards `Content-Type`, `Content-Language`, `Cache-Control`, `Content-Disposition`, `Content-Encoding`, `Last-Modified` (and `Content-Length` with `-content-length`)
-- Honors `If-Modified-Since` and replies `304 Not Modified` when appropriate
+- Emits `ETag` and honors conditional requests — `If-None-Match`, `If-Modified-Since`, `If-Match`, `If-Unmodified-Since`, `If-Range` — with `304 Not Modified` / `412 Precondition Failed` replies
 - Supports `Range` requests (single range) for partial downloads / video seeking, forwarded to GCS so only the requested bytes traverse the wire
 - Negotiates `Content-Encoding: gzip` when the client accepts it
 - Optional default index file (`-i`) for serving static sites
@@ -206,6 +206,42 @@ This is sufficient for [simple cross-origin requests](https://developer.mozilla.
 
 Requests that require a preflight (custom headers, credentialed `fetch`, non-`GET/HEAD/POST` methods) are not supported; front gcsproxy with a proxy like nginx if you need that.
 
+### Conditional requests
+
+gcsproxy emits the object's [GCS etag](https://cloud.google.com/storage/docs/hashes-etags) as the `ETag` header — it changes whenever the object's content or metadata is rewritten — and evaluates the standard [RFC 9110 preconditions](https://httpwg.org/specs/rfc9110.html#preconditions) against it and `Last-Modified`:
+
+```
+GET /test-bucket/app.js
+
+→ 200 OK
+   ETag: "CJqzl4Ol0PACEAE="
+   Last-Modified: Wed, 04 Mar 2026 05:06:07 GMT
+
+GET /test-bucket/app.js
+If-None-Match: "CJqzl4Ol0PACEAE="
+
+→ 304 Not Modified
+   ETag: "CJqzl4Ol0PACEAE="
+   Last-Modified: Wed, 04 Mar 2026 05:06:07 GMT
+   Cache-Control: <the object's Cache-Control, if any>
+```
+
+Supported preconditions:
+
+- `If-None-Match` (weak comparison, entity-tag lists, `*`) → `304 Not Modified` on match. When present, `If-Modified-Since` is ignored, as RFC 9110 requires.
+- `If-Modified-Since` → `304 Not Modified` when the object has not been modified after the given date.
+- `If-Match` (strong comparison, entity-tag lists, `*`) and `If-Unmodified-Since` → `412 Precondition Failed` when they do not hold. `If-Unmodified-Since` is ignored when `If-Match` is present.
+- `If-Range` — see [Range requests](#range-requests) below.
+
+Details:
+
+- `If-None-Match` uses weak comparison, so intermediaries that weaken the etag survive revalidation: a CDN or cache (nginx gzip filter, Varnish, ...) that recompresses the response downgrades `"abc"` to `W/"abc"`, and a later `If-None-Match: W/"abc"` still produces a `304` from gcsproxy.
+- Preconditions are evaluated before `Range` processing: a range request whose `If-None-Match` matches answers `304` (not `206`), and a failing `If-Match` answers `412`.
+- Date conditionals accept all three HTTP-date formats (IMF-fixdate, RFC 850, asctime) and are compared at the second granularity of `Last-Modified`; invalid dates are ignored per RFC 9110. Malformed entity-tags never match, and a present-but-empty `If-Match`/`If-None-Match` is treated as absent, matching `net/http` semantics.
+- Objects stored with `Content-Encoding: gzip` get a **weak** etag (`W/"…"`) plus `Vary: Accept-Encoding`, because the same URL serves either the raw gzip bytes or the GCS-transcoded body depending on the request's `Accept-Encoding` — two representations that a strong etag must not conflate.
+- Directory requests resolved through the default index file (`-i`, including `-walk-up-index`) and the SPA fallback (`-spa`) revalidate against the *resolved* index object's etag, so clients can cache the app shell. The custom not-found page (`-not-found`) is served with `404` and is never subject to preconditions.
+- Reads are pinned to the generation the validators were derived from, so a concurrent overwrite cannot pair a new body with a stale `ETag`/`Last-Modified`.
+
 ### Range requests
 
 gcsproxy advertises `Accept-Ranges: bytes` on full responses (except for `Content-Encoding: gzip` objects, see below) and serves a single byte range when the client sends a `Range` header:
@@ -227,7 +263,7 @@ Edge cases:
 
 - Range headers with a non-`bytes` unit are ignored and the request is served as a normal `200`, per [RFC 9110 §14.2](https://httpwg.org/specs/rfc9110.html#field.range). The same ignore-and-fall-through applies to byte-ranges that fail to parse as integers.
 - Byte-ranges that fall outside the object — or whose last byte precedes the first (e.g. `bytes=500-100`) — return `416` with a `Content-Range: bytes */<size>` header.
-- `If-Range` is not honored — the range is always served when an in-bounds `Range` header is present.
+- `If-Range` is honored: a strong entity-tag must match the current `ETag` (weak `W/"…"` tags never match), or an HTTP-date must exactly equal `Last-Modified`; otherwise the `Range` header is ignored and the full body is served with `200` — so a resumed download can never mix bytes from two object versions.
 - Objects stored with `Content-Encoding: gzip` cannot be served as partial content (GCS transcodes them and offsets become ambiguous), so the handler falls back to a full `200` body.
 
 ### Health check

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/textproto"
 	"net/url"
 	"os"
 	"strconv"
@@ -176,18 +177,11 @@ func (s *Server) proxy(w http.ResponseWriter, r *http.Request, bucket, object st
 		handleError(w, err)
 		return
 	}
-	if lastStrs, ok := r.Header["If-Modified-Since"]; ok && len(lastStrs) > 0 {
-		last, err := http.ParseTime(lastStrs[0])
-		if s.verbose && err != nil {
-			slog.Warn("could not parse If-Modified-Since", "err", err)
-		}
-		if !attrs.Updated.Truncate(time.Second).After(last) {
-			w.WriteHeader(304)
-			return
-		}
+	if s.checkPreconditions(w, r, attrs) {
+		return
 	}
 
-	if rangeHeader := r.Header.Get("Range"); rangeHeader != "" {
+	if rangeHeader := r.Header.Get("Range"); rangeHeader != "" && ifRangeAllowsPartial(r, attrs) {
 		s.streamRange(w, r, attrs, rangeHeader)
 		return
 	}
@@ -273,6 +267,11 @@ func (s *Server) serveObject(w http.ResponseWriter, r *http.Request, bucket, obj
 	if err != nil {
 		return err
 	}
+	// Preconditions apply only to would-be-2xx responses (RFC 9110 §13.2.1):
+	// the SPA fallback revalidates, the -not-found 404 page never does.
+	if status == http.StatusOK && s.checkPreconditions(w, r, attrs) {
+		return nil
+	}
 	return s.streamObject(w, r, attrs, status)
 }
 
@@ -280,18 +279,23 @@ func (s *Server) streamObject(w http.ResponseWriter, r *http.Request, attrs *sto
 	gzipAcceptable := strings.Contains(r.Header.Get("Accept-Encoding"), "gzip")
 
 	setTimeHeader(w, "Last-Modified", attrs.Updated)
+	setStrHeader(w, "ETag", objectETag(attrs))
 	setStrHeader(w, "Content-Type", attrs.ContentType)
 	setStrHeader(w, "Content-Language", attrs.ContentLanguage)
 	setStrHeader(w, "Cache-Control", attrs.CacheControl)
 	setStrHeader(w, "Content-Disposition", attrs.ContentDisposition)
-	if !strings.EqualFold(attrs.ContentEncoding, "gzip") {
+	if gzipStored(attrs) {
+		// The gzip and GCS-transcoded variants share this URL, so caches
+		// must key on the request's Accept-Encoding.
+		setStrHeader(w, "Vary", "Accept-Encoding")
+	} else {
 		setStrHeader(w, "Accept-Ranges", "bytes")
 	}
 
 	if r.Method == http.MethodHead {
 		// Mirror what a matching GET would emit; gzip-stored served without
 		// Accept-Encoding: gzip is transcoded by GCS, so neither field is set.
-		if strings.EqualFold(attrs.ContentEncoding, "gzip") {
+		if gzipStored(attrs) {
 			if gzipAcceptable {
 				setStrHeader(w, "Content-Encoding", attrs.ContentEncoding)
 				if s.contentLength {
@@ -305,7 +309,13 @@ func (s *Server) streamObject(w http.ResponseWriter, r *http.Request, attrs *sto
 		return nil
 	}
 
-	objr, err := s.client.Bucket(attrs.Bucket).Object(attrs.Name).ReadCompressed(gzipAcceptable).NewReader(r.Context())
+	obj := s.client.Bucket(attrs.Bucket).Object(attrs.Name)
+	if attrs.Generation != 0 {
+		// Pin the read to the generation the validators above were derived
+		// from, so a concurrent overwrite cannot pair a new body with them.
+		obj = obj.Generation(attrs.Generation)
+	}
+	objr, err := obj.ReadCompressed(gzipAcceptable).NewReader(r.Context())
 	if err != nil {
 		return err
 	}
@@ -325,7 +335,7 @@ func (s *Server) streamRange(w http.ResponseWriter, r *http.Request, attrs *stor
 	// GCS transcodes gzip-stored objects on download (verified empirically),
 	// so Range is silently ignored — fall back to a full 200. Other encodings
 	// (br, deflate, ...) are not transcoded and Range works normally.
-	if strings.EqualFold(attrs.ContentEncoding, "gzip") {
+	if gzipStored(attrs) {
 		if err := s.streamObject(w, r, attrs, http.StatusOK); err != nil {
 			handleError(w, err)
 		}
@@ -351,6 +361,7 @@ func (s *Server) streamRange(w http.ResponseWriter, r *http.Request, attrs *stor
 	}
 
 	setTimeHeader(w, "Last-Modified", attrs.Updated)
+	setStrHeader(w, "ETag", objectETag(attrs))
 	setStrHeader(w, "Content-Type", attrs.ContentType)
 	setStrHeader(w, "Content-Language", attrs.ContentLanguage)
 	setStrHeader(w, "Cache-Control", attrs.CacheControl)
@@ -367,7 +378,11 @@ func (s *Server) streamRange(w http.ResponseWriter, r *http.Request, attrs *stor
 		return
 	}
 
-	objr, err := s.client.Bucket(attrs.Bucket).Object(attrs.Name).NewRangeReader(r.Context(), start, length)
+	obj := s.client.Bucket(attrs.Bucket).Object(attrs.Name)
+	if attrs.Generation != 0 {
+		obj = obj.Generation(attrs.Generation)
+	}
+	objr, err := obj.NewRangeReader(r.Context(), start, length)
 	if err != nil {
 		handleError(w, err)
 		return
@@ -432,6 +447,201 @@ func parseSingleRange(header string, size int64) (start, length int64, err error
 		e = size - 1
 	}
 	return s, e - s + 1, nil
+}
+
+// --- conditional requests (RFC 9110 §13) ---
+
+// gzipStored reports whether the object is stored with Content-Encoding: gzip
+// and is therefore subject to GCS decompressive transcoding on download.
+func gzipStored(attrs *storage.ObjectAttrs) bool {
+	return strings.EqualFold(attrs.ContentEncoding, "gzip")
+}
+
+// objectETag returns the ETag header value for attrs, or "" when unknown.
+// gzip-stored objects get a weak tag because the same URL serves two
+// byte-different representations (raw gzip vs GCS-transcoded) depending on
+// the request's Accept-Encoding; the variants are semantically equivalent,
+// which is exactly what a weak tag promises.
+func objectETag(attrs *storage.ObjectAttrs) string {
+	if attrs.Etag == "" {
+		return ""
+	}
+	if gzipStored(attrs) {
+		return `W/"` + attrs.Etag + `"`
+	}
+	return `"` + attrs.Etag + `"`
+}
+
+// scanETag determines if a syntactically valid ETag is present at the start
+// of s (RFC 9110 §8.8.3). If so, it returns the ETag (including quotes and
+// any W/ prefix) and the remaining text after it; otherwise ("", "").
+// Ported from net/http/fs.go.
+func scanETag(s string) (etag string, remain string) {
+	s = textproto.TrimString(s)
+	start := 0
+	if strings.HasPrefix(s, "W/") {
+		start = 2
+	}
+	if len(s[start:]) < 2 || s[start] != '"' {
+		return "", ""
+	}
+	for i := start + 1; i < len(s); i++ {
+		c := s[i]
+		switch {
+		// Character values allowed in etagc.
+		case c == 0x21 || c >= 0x23 && c <= 0x7E || c >= 0x80:
+		case c == '"':
+			return s[:i+1], s[i+1:]
+		default:
+			return "", ""
+		}
+	}
+	return "", ""
+}
+
+// etagStrongMatch reports whether a and b match using strong ETag comparison:
+// both must be non-weak and identical.
+func etagStrongMatch(a, b string) bool {
+	return a == b && a != "" && a[0] == '"'
+}
+
+// etagWeakMatch reports whether a and b match using weak ETag comparison,
+// ignoring any W/ prefix on either side.
+func etagWeakMatch(a, b string) bool {
+	return strings.TrimPrefix(a, "W/") == strings.TrimPrefix(b, "W/")
+}
+
+// hasETagValues reports whether any of the header values is non-empty, so a
+// present-but-empty If-Match/If-None-Match field is treated as absent rather
+// than as a failing precondition, matching net/http semantics.
+func hasETagValues(values []string) bool {
+	for _, v := range values {
+		if textproto.TrimString(v) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// anyETagMatches reports whether target matches any entity-tag in the given
+// header values (each possibly a comma-separated list). "*" matches any
+// existing representation. A malformed member ends scanning of that value,
+// treating the rest as no-match, like net/http/fs.go.
+func anyETagMatches(values []string, target string, strong bool) bool {
+	match := etagWeakMatch
+	if strong {
+		match = etagStrongMatch
+	}
+	for _, buf := range values {
+		for {
+			buf = textproto.TrimString(buf)
+			if len(buf) == 0 {
+				break
+			}
+			if buf[0] == ',' {
+				buf = buf[1:]
+				continue
+			}
+			if buf[0] == '*' {
+				return true
+			}
+			etag, remain := scanETag(buf)
+			if etag == "" {
+				break
+			}
+			if match(etag, target) {
+				return true
+			}
+			buf = remain
+		}
+	}
+	return false
+}
+
+// writeNotModified sends 304 with the validator headers the equivalent 200
+// would carry (RFC 9110 §15.4.5). Representation headers (Content-Type,
+// Content-Length, ...) are deliberately omitted.
+func writeNotModified(w http.ResponseWriter, attrs *storage.ObjectAttrs) {
+	setStrHeader(w, "ETag", objectETag(attrs))
+	setTimeHeader(w, "Last-Modified", attrs.Updated)
+	setStrHeader(w, "Cache-Control", attrs.CacheControl)
+	if gzipStored(attrs) {
+		setStrHeader(w, "Vary", "Accept-Encoding")
+	}
+	w.WriteHeader(http.StatusNotModified)
+}
+
+// checkPreconditions evaluates If-Match, If-Unmodified-Since, If-None-Match
+// and If-Modified-Since against the resolved object in the order mandated by
+// RFC 9110 §13.2.2, writing a 412 or 304 when a precondition fails. It
+// reports whether the response has been written. Invalid HTTP-dates and
+// unknown (zero) modification times disable the date-based checks; malformed
+// entity-tags are treated as no-match.
+func (s *Server) checkPreconditions(w http.ResponseWriter, r *http.Request, attrs *storage.ObjectAttrs) bool {
+	if ifMatch := r.Header.Values("If-Match"); hasETagValues(ifMatch) {
+		if !anyETagMatches(ifMatch, objectETag(attrs), true) {
+			http.Error(w, "Precondition Failed", http.StatusPreconditionFailed)
+			return true
+		}
+	} else if ius, ok := header(r, "If-Unmodified-Since"); ok && !attrs.Updated.IsZero() {
+		t, err := http.ParseTime(ius)
+		if err != nil {
+			if s.verbose {
+				slog.Warn("could not parse If-Unmodified-Since", "err", err)
+			}
+		} else if attrs.Updated.Truncate(time.Second).After(t) {
+			http.Error(w, "Precondition Failed", http.StatusPreconditionFailed)
+			return true
+		}
+	}
+
+	if inm := r.Header.Values("If-None-Match"); hasETagValues(inm) {
+		if anyETagMatches(inm, objectETag(attrs), false) {
+			writeNotModified(w, attrs)
+			return true
+		}
+		// If-None-Match present but unmatched: If-Modified-Since MUST be
+		// ignored (RFC 9110 §13.1.3).
+		return false
+	}
+
+	if ims, ok := header(r, "If-Modified-Since"); ok && !attrs.Updated.IsZero() {
+		t, err := http.ParseTime(ims)
+		if err != nil {
+			if s.verbose {
+				slog.Warn("could not parse If-Modified-Since", "err", err)
+			}
+			return false
+		}
+		if !attrs.Updated.Truncate(time.Second).After(t) {
+			writeNotModified(w, attrs)
+			return true
+		}
+	}
+	return false
+}
+
+// ifRangeAllowsPartial reports whether a Range header may be honored given
+// the request's If-Range field (RFC 9110 §13.1.5): absent → yes; an
+// entity-tag must strong-match the current ETag (weak tags never match); an
+// HTTP-date must equal Last-Modified exactly, at the header's second
+// precision. On mismatch the caller serves the full body instead.
+func ifRangeAllowsPartial(r *http.Request, attrs *storage.ObjectAttrs) bool {
+	ir, ok := header(r, "If-Range")
+	if !ok || ir == "" {
+		return true
+	}
+	if etag, _ := scanETag(ir); etag != "" {
+		return etagStrongMatch(etag, objectETag(attrs))
+	}
+	if attrs.Updated.IsZero() {
+		return false
+	}
+	t, err := http.ParseTime(ir)
+	if err != nil {
+		return false
+	}
+	return attrs.Updated.Truncate(time.Second).Equal(t)
 }
 
 func healthCheck(w http.ResponseWriter, r *http.Request) {

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"compress/gzip"
 	"encoding/json"
 	"errors"
 	"io"
@@ -15,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/storage"
 	"github.com/fsouza/fake-gcs-server/fakestorage"
 )
 
@@ -1552,6 +1554,1101 @@ func TestProxy_HEAD_GzippedObject(t *testing.T) {
 		// Content-Encoding nor a definitive Content-Length applies.
 		if got := rec.Header().Get("Content-Encoding"); got != "" {
 			t.Errorf("Content-Encoding = %q, want empty", got)
+		}
+	})
+}
+
+// --- Conditional request tests (ETag / RFC 9110 preconditions) ---
+
+const (
+	testEtag     = "v1abc"
+	testCacheCtl = "max-age=60"
+)
+
+var testUpdated = time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC)
+
+// newETagServer returns a Server backed by a single object with known
+// validators (ETag, Last-Modified, Cache-Control) so conditional tests can
+// assert literal header values.
+func newETagServer(t *testing.T) *Server {
+	t.Helper()
+	return newTestServer(t, []fakestorage.Object{{
+		ObjectAttrs: fakestorage.ObjectAttrs{
+			BucketName:   testBucket,
+			Name:         testObject,
+			ContentType:  testCType,
+			CacheControl: testCacheCtl,
+			Etag:         testEtag,
+			Updated:      testUpdated,
+		},
+		Content: []byte(testContent),
+	}})
+}
+
+// newGzipETagServer stores plaintext gzip-compressed with
+// Content-Encoding: gzip, so fake-gcs-server transcodes it on download
+// exactly like real GCS.
+func newGzipETagServer(t *testing.T, plaintext string) *Server {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	if _, err := zw.Write([]byte(plaintext)); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return newTestServer(t, []fakestorage.Object{{
+		ObjectAttrs: fakestorage.ObjectAttrs{
+			BucketName:      testBucket,
+			Name:            testObject,
+			ContentType:     testCType,
+			ContentEncoding: "gzip",
+			Etag:            testEtag,
+			Updated:         testUpdated,
+		},
+		Content: buf.Bytes(),
+	}})
+}
+
+// doRequest performs a request for the standard test object with the given
+// extra headers and returns the recorded response.
+func doRequest(t *testing.T, s *Server, method string, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(method, "/"+testBucket+"/"+testObject, nil)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	s.handler().ServeHTTP(rec, req)
+	return rec
+}
+
+func TestObjectETag(t *testing.T) {
+	cases := []struct {
+		name  string
+		attrs *storage.ObjectAttrs
+		want  string
+	}{
+		{"identity", &storage.ObjectAttrs{Etag: "v1abc"}, `"v1abc"`},
+		{"gzip is weak", &storage.ObjectAttrs{Etag: "v1abc", ContentEncoding: "gzip"}, `W/"v1abc"`},
+		{"gzip case-insensitive", &storage.ObjectAttrs{Etag: "v1abc", ContentEncoding: "GZIP"}, `W/"v1abc"`},
+		{"other encoding stays strong", &storage.ObjectAttrs{Etag: "v1abc", ContentEncoding: "br"}, `"v1abc"`},
+		{"empty etag omitted", &storage.ObjectAttrs{}, ""},
+		{"empty etag gzip omitted", &storage.ObjectAttrs{ContentEncoding: "gzip"}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := objectETag(tc.attrs); got != tc.want {
+				t.Errorf("objectETag() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestScanETag(t *testing.T) {
+	cases := []struct {
+		name       string
+		in         string
+		wantETag   string
+		wantRemain string
+	}{
+		{"strong", `"x"`, `"x"`, ""},
+		{"weak", `W/"x"`, `W/"x"`, ""},
+		{"leading whitespace", `  "x"`, `"x"`, ""},
+		{"list remainder", `"a", "b"`, `"a"`, `, "b"`},
+		{"empty opaque tag", `""`, `""`, ""},
+		{"obs-text bytes allowed", "\"caf\xc3\xa9\"", "\"caf\xc3\xa9\"", ""},
+		{"unterminated", `"x`, "", ""},
+		{"missing quotes", `x`, "", ""},
+		{"long but unquoted", `ab`, "", ""},
+		{"lone weak prefix", `W/`, "", ""},
+		{"control char inside", "\"x\x01y\"", "", ""},
+		{"embedded space invalid", `"a b"`, "", ""},
+		{"empty input", ``, "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			etag, remain := scanETag(tc.in)
+			if etag != tc.wantETag || remain != tc.wantRemain {
+				t.Errorf("scanETag(%q) = (%q, %q), want (%q, %q)", tc.in, etag, remain, tc.wantETag, tc.wantRemain)
+			}
+		})
+	}
+}
+
+func TestAnyETagMatches(t *testing.T) {
+	cases := []struct {
+		name   string
+		values []string
+		target string
+		strong bool
+		want   bool
+	}{
+		{"strong exact", []string{`"x"`}, `"x"`, true, true},
+		{"strong rejects weak header tag", []string{`W/"x"`}, `"x"`, true, false},
+		{"strong rejects weak target", []string{`"x"`}, `W/"x"`, true, false},
+		{"weak accepts weak header tag", []string{`W/"x"`}, `"x"`, false, true},
+		{"weak accepts weak target", []string{`"x"`}, `W/"x"`, false, true},
+		{"identical weak tags fail strong compare", []string{`W/"x"`}, `W/"x"`, true, false},
+		{"identical weak tags pass weak compare", []string{`W/"x"`}, `W/"x"`, false, true},
+		{"mismatch", []string{`"y"`}, `"x"`, true, false},
+		{"list with spaces", []string{`"a", "b" , "x"`}, `"x"`, true, true},
+		{"multiple header values", []string{`"a"`, `"x"`}, `"x"`, true, true},
+		{"star", []string{`*`}, `"x"`, true, true},
+		{"star with empty target", []string{`*`}, ``, true, true},
+		{"empty target never matches tags", []string{`"x"`, `""`}, ``, false, false},
+		{"malformed stops that value", []string{`garbage, "x"`}, `"x"`, true, false},
+		{"malformed value then matching value", []string{`garbage`, `"x"`}, `"x"`, true, true},
+		{"empty values", nil, `"x"`, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := anyETagMatches(tc.values, tc.target, tc.strong); got != tc.want {
+				t.Errorf("anyETagMatches(%q, %q, %v) = %v, want %v", tc.values, tc.target, tc.strong, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIfRangeAllowsPartial(t *testing.T) {
+	attrs := &storage.ObjectAttrs{Etag: "v1abc", Updated: testUpdated}
+	weakAttrs := &storage.ObjectAttrs{Etag: "v1abc", ContentEncoding: "gzip", Updated: testUpdated}
+	noTimeAttrs := &storage.ObjectAttrs{Etag: "v1abc"}
+	cases := []struct {
+		name    string
+		ifRange string
+		attrs   *storage.ObjectAttrs
+		want    bool
+	}{
+		{"absent", "", attrs, true},
+		{"strong match", `"v1abc"`, attrs, true},
+		{"strong mismatch", `"other"`, attrs, false},
+		{"weak tag never matches", `W/"v1abc"`, attrs, false},
+		{"strong tag against weak object tag", `"v1abc"`, weakAttrs, false},
+		{"identical weak tags still never match", `W/"v1abc"`, weakAttrs, false},
+		{"date equal", testUpdated.Format(http.TimeFormat), attrs, true},
+		{"date earlier", testUpdated.Add(-time.Hour).Format(http.TimeFormat), attrs, false},
+		{"date with zero updated", testUpdated.Format(http.TimeFormat), noTimeAttrs, false},
+		{"garbage", "garbage", attrs, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/x", nil)
+			if tc.ifRange != "" {
+				req.Header.Set("If-Range", tc.ifRange)
+			}
+			if got := ifRangeAllowsPartial(req, tc.attrs); got != tc.want {
+				t.Errorf("ifRangeAllowsPartial(If-Range: %q) = %v, want %v", tc.ifRange, got, tc.want)
+			}
+		})
+	}
+
+	t.Run("empty value treated as absent", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/x", nil)
+		req.Header.Set("If-Range", "")
+		if !ifRangeAllowsPartial(req, attrs) {
+			t.Error("ifRangeAllowsPartial(If-Range: <empty>) = false, want true")
+		}
+	})
+}
+
+func TestHasETagValues(t *testing.T) {
+	cases := []struct {
+		name   string
+		values []string
+		want   bool
+	}{
+		{"nil", nil, false},
+		{"single empty", []string{""}, false},
+		{"whitespace only", []string{"  "}, false},
+		{"empty then tag", []string{"", `"x"`}, true},
+		{"tag", []string{`"x"`}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasETagValues(tc.values); got != tc.want {
+				t.Errorf("hasETagValues(%q) = %v, want %v", tc.values, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestProxy_ETag_OnGet(t *testing.T) {
+	s := newETagServer(t)
+	rec := doRequest(t, s, http.MethodGet, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got := rec.Header().Get("ETag"); got != `"`+testEtag+`"` {
+		t.Errorf("ETag = %q, want %q", got, `"`+testEtag+`"`)
+	}
+	if got := rec.Body.String(); got != testContent {
+		t.Errorf("body = %q, want %q", got, testContent)
+	}
+}
+
+func TestProxy_ETag_OnHead(t *testing.T) {
+	s := newETagServer(t)
+	rec := doRequest(t, s, http.MethodHead, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got := rec.Header().Get("ETag"); got != `"`+testEtag+`"` {
+		t.Errorf("ETag = %q, want %q", got, `"`+testEtag+`"`)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("body should be empty, got %q", rec.Body.String())
+	}
+}
+
+func TestProxy_ETag_On206Range(t *testing.T) {
+	s := newETagServer(t)
+	rec := doRequest(t, s, http.MethodGet, map[string]string{"Range": "bytes=2-5"})
+	if rec.Code != http.StatusPartialContent {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusPartialContent)
+	}
+	if got := rec.Header().Get("ETag"); got != `"`+testEtag+`"` {
+		t.Errorf("ETag = %q, want %q", got, `"`+testEtag+`"`)
+	}
+	if got := rec.Body.String(); got != testContent[2:6] {
+		t.Errorf("body = %q, want %q", got, testContent[2:6])
+	}
+	if got := rec.Header().Get("Content-Range"); got == "" {
+		t.Error("Content-Range header is missing")
+	}
+}
+
+func TestProxy_ETag_GzipObject_WeakWithVary(t *testing.T) {
+	const plaintext = "gzip me please, gcsproxy"
+	wantETag := `W/"` + testEtag + `"`
+
+	t.Run("Accept-Encoding gzip", func(t *testing.T) {
+		s := newGzipETagServer(t, plaintext)
+		rec := doRequest(t, s, http.MethodGet, map[string]string{"Accept-Encoding": "gzip"})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+		}
+		if got := rec.Header().Get("ETag"); got != wantETag {
+			t.Errorf("ETag = %q, want %q", got, wantETag)
+		}
+		if got := rec.Header().Get("Vary"); got != "Accept-Encoding" {
+			t.Errorf("Vary = %q, want %q", got, "Accept-Encoding")
+		}
+		if got := rec.Header().Get("Content-Encoding"); got != "gzip" {
+			t.Errorf("Content-Encoding = %q, want %q", got, "gzip")
+		}
+		zr, err := gzip.NewReader(rec.Body)
+		if err != nil {
+			t.Fatalf("body is not gzip: %v", err)
+		}
+		decompressed, err := io.ReadAll(zr)
+		if err != nil {
+			t.Fatalf("gunzip: %v", err)
+		}
+		if string(decompressed) != plaintext {
+			t.Errorf("decompressed body = %q, want %q", decompressed, plaintext)
+		}
+	})
+
+	t.Run("no Accept-Encoding", func(t *testing.T) {
+		s := newGzipETagServer(t, plaintext)
+		rec := doRequest(t, s, http.MethodGet, nil)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+		}
+		if got := rec.Header().Get("ETag"); got != wantETag {
+			t.Errorf("ETag = %q, want %q", got, wantETag)
+		}
+		if got := rec.Header().Get("Vary"); got != "Accept-Encoding" {
+			t.Errorf("Vary = %q, want %q", got, "Accept-Encoding")
+		}
+		if got := rec.Header().Get("Content-Encoding"); got != "" {
+			t.Errorf("Content-Encoding = %q, want empty (transcoded)", got)
+		}
+		if got := rec.Body.String(); got != plaintext {
+			t.Errorf("body = %q, want %q", got, plaintext)
+		}
+	})
+}
+
+func TestProxy_IfNoneMatch_Match(t *testing.T) {
+	s := newETagServer(t)
+	rec := doRequest(t, s, http.MethodGet, map[string]string{"If-None-Match": `"` + testEtag + `"`})
+	if rec.Code != http.StatusNotModified {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotModified)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("body should be empty, got %q", rec.Body.String())
+	}
+	// 304 must carry the validators the 200 would have (RFC 9110 §15.4.5).
+	if got := rec.Header().Get("ETag"); got != `"`+testEtag+`"` {
+		t.Errorf("ETag = %q, want %q", got, `"`+testEtag+`"`)
+	}
+	if got := rec.Header().Get("Last-Modified"); got != testUpdated.Format(http.TimeFormat) {
+		t.Errorf("Last-Modified = %q, want %q", got, testUpdated.Format(http.TimeFormat))
+	}
+	if got := rec.Header().Get("Cache-Control"); got != testCacheCtl {
+		t.Errorf("Cache-Control = %q, want %q", got, testCacheCtl)
+	}
+	if got := rec.Header().Get("Vary"); got != "" {
+		t.Errorf("Vary = %q, want empty for non-gzip object", got)
+	}
+}
+
+func TestProxy_IfNoneMatch_WeakFormMatch(t *testing.T) {
+	s := newETagServer(t)
+	rec := doRequest(t, s, http.MethodGet, map[string]string{"If-None-Match": `W/"` + testEtag + `"`})
+	if rec.Code != http.StatusNotModified {
+		t.Errorf("status = %d, want %d (weak comparison)", rec.Code, http.StatusNotModified)
+	}
+}
+
+func TestProxy_IfNoneMatch_ListMatch(t *testing.T) {
+	s := newETagServer(t)
+	rec := doRequest(t, s, http.MethodGet, map[string]string{"If-None-Match": `"nope", W/"other", "` + testEtag + `"`})
+	if rec.Code != http.StatusNotModified {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusNotModified)
+	}
+}
+
+func TestProxy_IfNoneMatch_Star(t *testing.T) {
+	s := newETagServer(t)
+	rec := doRequest(t, s, http.MethodGet, map[string]string{"If-None-Match": "*"})
+	if rec.Code != http.StatusNotModified {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusNotModified)
+	}
+}
+
+func TestProxy_IfNoneMatch_Mismatch(t *testing.T) {
+	s := newETagServer(t)
+	rec := doRequest(t, s, http.MethodGet, map[string]string{"If-None-Match": `"stale"`})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got := rec.Body.String(); got != testContent {
+		t.Errorf("body = %q, want %q", got, testContent)
+	}
+}
+
+func TestProxy_IfNoneMatch_MultipleHeaderLines(t *testing.T) {
+	s := newETagServer(t)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/"+testBucket+"/"+testObject, nil)
+	req.Header.Add("If-None-Match", `"a"`)
+	req.Header.Add("If-None-Match", `"`+testEtag+`"`)
+	s.handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotModified {
+		t.Errorf("status = %d, want %d (all header lines must be scanned)", rec.Code, http.StatusNotModified)
+	}
+}
+
+func TestProxy_IfNoneMatch_Malformed(t *testing.T) {
+	s := newETagServer(t)
+	// Unquoted value is not a valid entity-tag: treated as no-match.
+	rec := doRequest(t, s, http.MethodGet, map[string]string{"If-None-Match": testEtag})
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+func TestProxy_IfNoneMatch_HEAD(t *testing.T) {
+	s := newETagServer(t)
+	rec := doRequest(t, s, http.MethodHead, map[string]string{"If-None-Match": `"` + testEtag + `"`})
+	if rec.Code != http.StatusNotModified {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotModified)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("body should be empty, got %q", rec.Body.String())
+	}
+}
+
+func TestProxy_IfNoneMatch_GzipVariants(t *testing.T) {
+	const plaintext = "gzip me please, gcsproxy"
+	cases := []struct {
+		name    string
+		inm     string
+		headers map[string]string
+	}{
+		{"weak tag with gzip accept", `W/"` + testEtag + `"`, map[string]string{"Accept-Encoding": "gzip"}},
+		{"weak tag without accept-encoding", `W/"` + testEtag + `"`, nil},
+		{"strong-form tag still matches weakly", `"` + testEtag + `"`, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newGzipETagServer(t, plaintext)
+			headers := map[string]string{"If-None-Match": tc.inm}
+			for k, v := range tc.headers {
+				headers[k] = v
+			}
+			rec := doRequest(t, s, http.MethodGet, headers)
+			if rec.Code != http.StatusNotModified {
+				t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotModified)
+			}
+			if got := rec.Header().Get("Vary"); got != "Accept-Encoding" {
+				t.Errorf("Vary = %q, want %q (304 for gzip object)", got, "Accept-Encoding")
+			}
+		})
+	}
+}
+
+func TestProxy_IfNoneMatch_TakesPrecedenceOverIMS(t *testing.T) {
+	t.Run("INM mismatch ignores satisfied IMS", func(t *testing.T) {
+		s := newETagServer(t)
+		rec := doRequest(t, s, http.MethodGet, map[string]string{
+			"If-None-Match":     `"stale"`,
+			"If-Modified-Since": testUpdated.Format(http.TimeFormat),
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d (IMS must be ignored when INM present)", rec.Code, http.StatusOK)
+		}
+		if got := rec.Body.String(); got != testContent {
+			t.Errorf("body = %q, want %q", got, testContent)
+		}
+	})
+
+	t.Run("INM match wins over stale IMS", func(t *testing.T) {
+		s := newETagServer(t)
+		rec := doRequest(t, s, http.MethodGet, map[string]string{
+			"If-None-Match":     `"` + testEtag + `"`,
+			"If-Modified-Since": testUpdated.Add(-time.Hour).Format(http.TimeFormat),
+		})
+		if rec.Code != http.StatusNotModified {
+			t.Errorf("status = %d, want %d", rec.Code, http.StatusNotModified)
+		}
+	})
+}
+
+func TestProxy_IfModifiedSince_304_IncludesValidatorHeaders(t *testing.T) {
+	s := newETagServer(t)
+	rec := doRequest(t, s, http.MethodGet, map[string]string{
+		"If-Modified-Since": testUpdated.Format(http.TimeFormat),
+	})
+	if rec.Code != http.StatusNotModified {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotModified)
+	}
+	if got := rec.Header().Get("ETag"); got != `"`+testEtag+`"` {
+		t.Errorf("ETag = %q, want %q", got, `"`+testEtag+`"`)
+	}
+	if got := rec.Header().Get("Last-Modified"); got != testUpdated.Format(http.TimeFormat) {
+		t.Errorf("Last-Modified = %q, want %q", got, testUpdated.Format(http.TimeFormat))
+	}
+	if got := rec.Header().Get("Cache-Control"); got != testCacheCtl {
+		t.Errorf("Cache-Control = %q, want %q", got, testCacheCtl)
+	}
+	// Representation headers must be absent on 304.
+	if got := rec.Header().Get("Content-Type"); got != "" {
+		t.Errorf("Content-Type = %q, want empty on 304", got)
+	}
+	if got := rec.Header().Get("Accept-Ranges"); got != "" {
+		t.Errorf("Accept-Ranges = %q, want empty on 304", got)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("body should be empty, got %q", rec.Body.String())
+	}
+}
+
+func TestProxy_Range_IfNoneMatchMatch_Returns304(t *testing.T) {
+	s := newETagServer(t)
+	rec := doRequest(t, s, http.MethodGet, map[string]string{
+		"Range":         "bytes=0-3",
+		"If-None-Match": `"` + testEtag + `"`,
+	})
+	if rec.Code != http.StatusNotModified {
+		t.Fatalf("status = %d, want %d (preconditions run before Range)", rec.Code, http.StatusNotModified)
+	}
+	if got := rec.Header().Get("Content-Range"); got != "" {
+		t.Errorf("Content-Range = %q, want empty on 304", got)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("body should be empty, got %q", rec.Body.String())
+	}
+}
+
+func TestProxy_IfRange_ETagMatch_Serves206(t *testing.T) {
+	s := newETagServer(t)
+	rec := doRequest(t, s, http.MethodGet, map[string]string{
+		"Range":    "bytes=2-5",
+		"If-Range": `"` + testEtag + `"`,
+	})
+	if rec.Code != http.StatusPartialContent {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusPartialContent)
+	}
+	if got := rec.Body.String(); got != testContent[2:6] {
+		t.Errorf("body = %q, want %q", got, testContent[2:6])
+	}
+}
+
+func TestProxy_IfRange_ETagMismatch_ServesFull200(t *testing.T) {
+	s := newETagServer(t)
+	rec := doRequest(t, s, http.MethodGet, map[string]string{
+		"Range":    "bytes=2-5",
+		"If-Range": `"old"`,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (changed validator must disable Range)", rec.Code, http.StatusOK)
+	}
+	if got := rec.Body.String(); got != testContent {
+		t.Errorf("body = %q, want full body %q", got, testContent)
+	}
+	if got := rec.Header().Get("Content-Range"); got != "" {
+		t.Errorf("Content-Range = %q, want empty", got)
+	}
+}
+
+func TestProxy_IfRange_WeakETag_ServesFull200(t *testing.T) {
+	s := newETagServer(t)
+	rec := doRequest(t, s, http.MethodGet, map[string]string{
+		"Range":    "bytes=2-5",
+		"If-Range": `W/"` + testEtag + `"`,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (If-Range requires strong comparison)", rec.Code, http.StatusOK)
+	}
+	if got := rec.Body.String(); got != testContent {
+		t.Errorf("body = %q, want full body %q", got, testContent)
+	}
+}
+
+func TestProxy_IfRange_DateMatch_Serves206(t *testing.T) {
+	s := newETagServer(t)
+	rec := doRequest(t, s, http.MethodGet, map[string]string{
+		"Range":    "bytes=2-5",
+		"If-Range": testUpdated.Format(http.TimeFormat),
+	})
+	if rec.Code != http.StatusPartialContent {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusPartialContent)
+	}
+	if got := rec.Body.String(); got != testContent[2:6] {
+		t.Errorf("body = %q, want %q", got, testContent[2:6])
+	}
+}
+
+func TestProxy_IfRange_DateMismatch_ServesFull200(t *testing.T) {
+	s := newETagServer(t)
+	rec := doRequest(t, s, http.MethodGet, map[string]string{
+		"Range":    "bytes=2-5",
+		"If-Range": testUpdated.Add(-time.Hour).Format(http.TimeFormat),
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (non-matching date must disable Range)", rec.Code, http.StatusOK)
+	}
+	if got := rec.Body.String(); got != testContent {
+		t.Errorf("body = %q, want full body %q", got, testContent)
+	}
+}
+
+func TestProxy_IfMatch_Match_Serves200(t *testing.T) {
+	s := newETagServer(t)
+	rec := doRequest(t, s, http.MethodGet, map[string]string{"If-Match": `"` + testEtag + `"`})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got := rec.Body.String(); got != testContent {
+		t.Errorf("body = %q, want %q", got, testContent)
+	}
+}
+
+func TestProxy_IfMatch_Mismatch_Returns412(t *testing.T) {
+	s := newETagServer(t)
+	rec := doRequest(t, s, http.MethodGet, map[string]string{"If-Match": `"stale"`})
+	if rec.Code != http.StatusPreconditionFailed {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusPreconditionFailed)
+	}
+}
+
+func TestProxy_IfMatch_Star_Serves200(t *testing.T) {
+	s := newETagServer(t)
+	rec := doRequest(t, s, http.MethodGet, map[string]string{"If-Match": "*"})
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+func TestProxy_IfMatch_WeakForm_Returns412(t *testing.T) {
+	s := newETagServer(t)
+	rec := doRequest(t, s, http.MethodGet, map[string]string{"If-Match": `W/"` + testEtag + `"`})
+	if rec.Code != http.StatusPreconditionFailed {
+		t.Errorf("status = %d, want %d (If-Match requires strong comparison)", rec.Code, http.StatusPreconditionFailed)
+	}
+}
+
+func TestProxy_IfUnmodifiedSince_Satisfied_Serves200(t *testing.T) {
+	s := newETagServer(t)
+	rec := doRequest(t, s, http.MethodGet, map[string]string{
+		"If-Unmodified-Since": testUpdated.Format(http.TimeFormat),
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got := rec.Body.String(); got != testContent {
+		t.Errorf("body = %q, want %q", got, testContent)
+	}
+}
+
+func TestProxy_IfUnmodifiedSince_Stale_Returns412(t *testing.T) {
+	s := newETagServer(t)
+	rec := doRequest(t, s, http.MethodGet, map[string]string{
+		"If-Unmodified-Since": testUpdated.Add(-time.Hour).Format(http.TimeFormat),
+	})
+	if rec.Code != http.StatusPreconditionFailed {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusPreconditionFailed)
+	}
+}
+
+func TestProxy_IfMatch_PrecedenceOverIfUnmodifiedSince(t *testing.T) {
+	s := newETagServer(t)
+	rec := doRequest(t, s, http.MethodGet, map[string]string{
+		"If-Match":            `"` + testEtag + `"`,
+		"If-Unmodified-Since": testUpdated.Add(-time.Hour).Format(http.TimeFormat),
+	})
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d (IUS must be ignored when If-Match present)", rec.Code, http.StatusOK)
+	}
+}
+
+func TestProxy_IfUnmodifiedSince_InvalidDate_Ignored(t *testing.T) {
+	s := newETagServer(t)
+	rec := doRequest(t, s, http.MethodGet, map[string]string{
+		"If-Unmodified-Since": "not-a-date",
+	})
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d (invalid HTTP-date must be ignored)", rec.Code, http.StatusOK)
+	}
+}
+
+func TestProxy_IfMatch_EmptyHeader_TreatedAsAbsent(t *testing.T) {
+	// A present-but-empty If-Match must not fail the precondition
+	// (net/http semantics for invalid field syntax).
+	s := newETagServer(t)
+	rec := doRequest(t, s, http.MethodGet, map[string]string{"If-Match": ""})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got := rec.Body.String(); got != testContent {
+		t.Errorf("body = %q, want %q", got, testContent)
+	}
+}
+
+func TestProxy_IfNoneMatch_EmptyHeader_DoesNotDisableIMS(t *testing.T) {
+	// A present-but-empty If-None-Match is treated as absent, so a matching
+	// If-Modified-Since must still produce a 304.
+	s := newETagServer(t)
+	rec := doRequest(t, s, http.MethodGet, map[string]string{
+		"If-None-Match":     "",
+		"If-Modified-Since": testUpdated.Format(http.TimeFormat),
+	})
+	if rec.Code != http.StatusNotModified {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusNotModified)
+	}
+}
+
+func TestProxy_IfModifiedSince_InvalidDate_Ignored(t *testing.T) {
+	s := newETagServer(t)
+	rec := doRequest(t, s, http.MethodGet, map[string]string{
+		"If-Modified-Since": "not-a-date",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (invalid HTTP-date must be ignored)", rec.Code, http.StatusOK)
+	}
+	if got := rec.Body.String(); got != testContent {
+		t.Errorf("body = %q, want %q", got, testContent)
+	}
+}
+
+func TestProxy_Range_IfMatchMismatch_Returns412(t *testing.T) {
+	s := newETagServer(t)
+	rec := doRequest(t, s, http.MethodGet, map[string]string{
+		"Range":    "bytes=2-5",
+		"If-Match": `"stale"`,
+	})
+	if rec.Code != http.StatusPreconditionFailed {
+		t.Fatalf("status = %d, want %d (preconditions run before Range)", rec.Code, http.StatusPreconditionFailed)
+	}
+	if got := rec.Header().Get("Content-Range"); got != "" {
+		t.Errorf("Content-Range = %q, want empty on 412", got)
+	}
+}
+
+func TestProxy_IfRange_MatchButRangeUnsatisfiable_Returns416(t *testing.T) {
+	// If-Range only decides whether Range is honored; an in-date validator
+	// with an out-of-bounds range must still produce 416.
+	s := newETagServer(t)
+	rec := doRequest(t, s, http.MethodGet, map[string]string{
+		"Range":    "bytes=9999-",
+		"If-Range": `"` + testEtag + `"`,
+	})
+	if rec.Code != http.StatusRequestedRangeNotSatisfiable {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusRequestedRangeNotSatisfiable)
+	}
+	if got := rec.Header().Get("Content-Range"); !strings.HasPrefix(got, "bytes */") {
+		t.Errorf("Content-Range = %q, want bytes */<size>", got)
+	}
+}
+
+func TestProxy_IfUnmodifiedSince_ExactSecondBoundary(t *testing.T) {
+	// Last-Modified truncates to whole seconds; sub-second object precision
+	// must not turn an equal-second IUS into a spurious 412.
+	updated := testUpdated.Add(300 * time.Millisecond)
+	s := newTestServer(t, []fakestorage.Object{{
+		ObjectAttrs: fakestorage.ObjectAttrs{
+			BucketName: testBucket,
+			Name:       testObject,
+			Etag:       testEtag,
+			Updated:    updated,
+		},
+		Content: []byte(testContent),
+	}})
+	rec := doRequest(t, s, http.MethodGet, map[string]string{
+		"If-Unmodified-Since": updated.Truncate(time.Second).Format(http.TimeFormat),
+	})
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+func TestProxy_DateFormats(t *testing.T) {
+	// http.ParseTime accepts the three HTTP-date formats of RFC 9110 §5.6.7.
+	formats := []struct {
+		name   string
+		layout string
+	}{
+		{"IMF-fixdate", http.TimeFormat},
+		{"RFC850", time.RFC850},
+		{"asctime", time.ANSIC},
+	}
+	for _, f := range formats {
+		t.Run(f.name, func(t *testing.T) {
+			t.Run("If-Modified-Since 304", func(t *testing.T) {
+				s := newETagServer(t)
+				rec := doRequest(t, s, http.MethodGet, map[string]string{
+					"If-Modified-Since": testUpdated.Format(f.layout),
+				})
+				if rec.Code != http.StatusNotModified {
+					t.Errorf("status = %d, want %d", rec.Code, http.StatusNotModified)
+				}
+			})
+			t.Run("If-Unmodified-Since 412", func(t *testing.T) {
+				s := newETagServer(t)
+				rec := doRequest(t, s, http.MethodGet, map[string]string{
+					"If-Unmodified-Since": testUpdated.Add(-time.Hour).Format(f.layout),
+				})
+				if rec.Code != http.StatusPreconditionFailed {
+					t.Errorf("status = %d, want %d", rec.Code, http.StatusPreconditionFailed)
+				}
+			})
+			t.Run("If-Range 206", func(t *testing.T) {
+				s := newETagServer(t)
+				rec := doRequest(t, s, http.MethodGet, map[string]string{
+					"Range":    "bytes=2-5",
+					"If-Range": testUpdated.Format(f.layout),
+				})
+				if rec.Code != http.StatusPartialContent {
+					t.Errorf("status = %d, want %d", rec.Code, http.StatusPartialContent)
+				}
+			})
+		})
+	}
+}
+
+func TestCheckPreconditions_ZeroUpdated(t *testing.T) {
+	// Unknown (zero) modification time disables the date conditionals
+	// instead of producing a bogus 304/412. The fake always assigns an
+	// Updated time, so this is exercised at the unit level.
+	s := &Server{}
+	attrs := &storage.ObjectAttrs{Etag: testEtag}
+	cases := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{"If-Modified-Since ignored", "If-Modified-Since", testUpdated.Format(http.TimeFormat)},
+		{"If-Unmodified-Since ignored", "If-Unmodified-Since", testUpdated.Add(-time.Hour).Format(http.TimeFormat)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/x", nil)
+			req.Header.Set(tc.key, tc.value)
+			if s.checkPreconditions(rec, req, attrs) {
+				t.Errorf("checkPreconditions wrote %d, want pass-through for zero Updated", rec.Code)
+			}
+		})
+	}
+
+	t.Run("If-None-Match still validates", func(t *testing.T) {
+		// ETag validation is independent of the modification time: a match
+		// must 304 even with zero Updated, just without a Last-Modified.
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/x", nil)
+		req.Header.Set("If-None-Match", `"`+testEtag+`"`)
+		if !s.checkPreconditions(rec, req, attrs) {
+			t.Fatal("checkPreconditions = false, want 304 written")
+		}
+		if rec.Code != http.StatusNotModified {
+			t.Errorf("status = %d, want %d", rec.Code, http.StatusNotModified)
+		}
+		if got := rec.Header().Get("Last-Modified"); got != "" {
+			t.Errorf("Last-Modified = %q, want empty for zero Updated", got)
+		}
+	})
+}
+
+func TestCheckPreconditions_InvalidDate_VerboseWarnLogged(t *testing.T) {
+	s := &Server{verbose: true}
+	attrs := &storage.ObjectAttrs{Etag: testEtag, Updated: testUpdated}
+	cases := []struct {
+		key     string
+		wantLog string
+	}{
+		{"If-Unmodified-Since", "If-Unmodified-Since"},
+		{"If-Modified-Since", "If-Modified-Since"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.key, func(t *testing.T) {
+			var buf bytes.Buffer
+			installLogger(t, slog.NewTextHandler(&buf, nil))
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/x", nil)
+			req.Header.Set(tc.key, "not-a-date")
+			if s.checkPreconditions(rec, req, attrs) {
+				t.Errorf("checkPreconditions wrote %d, want pass-through for invalid date", rec.Code)
+			}
+			if !strings.Contains(buf.String(), tc.wantLog) {
+				t.Errorf("log output %q does not mention %q", buf.String(), tc.wantLog)
+			}
+		})
+	}
+}
+
+func TestProxy_E2E_DateHeader(t *testing.T) {
+	// The Date header is added by net/http's server, which recorder-based
+	// tests bypass — so drive a real server.
+	s := newETagServer(t)
+	srv := httptest.NewServer(s.handler())
+	defer srv.Close()
+
+	get := func(t *testing.T, inm string) *http.Response {
+		t.Helper()
+		req, err := http.NewRequest(http.MethodGet, srv.URL+"/"+testBucket+"/"+testObject, nil)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		if inm != "" {
+			req.Header.Set("If-None-Match", inm)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Do: %v", err)
+		}
+		t.Cleanup(func() { resp.Body.Close() })
+		return resp
+	}
+
+	t.Run("200", func(t *testing.T) {
+		resp := get(t, "")
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+		if resp.Header.Get("Date") == "" {
+			t.Error("Date header is missing on 200")
+		}
+	})
+
+	t.Run("304", func(t *testing.T) {
+		resp := get(t, `"`+testEtag+`"`)
+		if resp.StatusCode != http.StatusNotModified {
+			t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusNotModified)
+		}
+		if resp.Header.Get("Date") == "" {
+			t.Error("Date header is missing on 304")
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("ReadAll: %v", err)
+		}
+		if len(body) != 0 {
+			t.Errorf("body should be empty, got %q", body)
+		}
+	})
+}
+
+func TestProxy_SPA_Fallback_Conditional(t *testing.T) {
+	newSPAServer := func(t *testing.T) *Server {
+		t.Helper()
+		s := newTestServer(t, []fakestorage.Object{{
+			ObjectAttrs: fakestorage.ObjectAttrs{
+				BucketName:  testBucket,
+				Name:        "index.html",
+				ContentType: "text/html",
+				Etag:        "idx1",
+				Updated:     testUpdated,
+			},
+			Content: []byte(testIndexBody),
+		}})
+		s.defaultIndex = "index.html"
+		s.spa = true
+		return s
+	}
+
+	t.Run("first fetch carries index ETag", func(t *testing.T) {
+		s := newSPAServer(t)
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/"+testBucket+"/some/spa/route", nil)
+		s.handler().ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+		}
+		if got := rec.Header().Get("ETag"); got != `"idx1"` {
+			t.Errorf("ETag = %q, want %q", got, `"idx1"`)
+		}
+	})
+
+	t.Run("revalidation returns 304", func(t *testing.T) {
+		s := newSPAServer(t)
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/"+testBucket+"/some/spa/route", nil)
+		req.Header.Set("If-None-Match", `"idx1"`)
+		s.handler().ServeHTTP(rec, req)
+		if rec.Code != http.StatusNotModified {
+			t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotModified)
+		}
+		if rec.Body.Len() != 0 {
+			t.Errorf("body should be empty, got %q", rec.Body.String())
+		}
+	})
+}
+
+func TestProxy_NotFound_Fallback_IgnoresConditionals(t *testing.T) {
+	const notFoundBody = "<html>oops</html>"
+	s := newTestServer(t, []fakestorage.Object{{
+		ObjectAttrs: fakestorage.ObjectAttrs{
+			BucketName:  testBucket,
+			Name:        "404.html",
+			ContentType: "text/html",
+			Etag:        "nf1",
+			Updated:     testUpdated,
+		},
+		Content: []byte(notFoundBody),
+	}})
+	s.notFoundPath = "404.html"
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/"+testBucket+"/missing.txt", nil)
+	// Preconditions apply only to would-be-2xx responses: even validators
+	// matching the 404 page itself must not turn the 404 into a 304/412.
+	req.Header.Set("If-None-Match", `"nf1"`)
+	req.Header.Set("If-Modified-Since", testUpdated.Format(http.TimeFormat))
+	s.handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+	if got := rec.Body.String(); got != notFoundBody {
+		t.Errorf("body = %q, want %q", got, notFoundBody)
+	}
+}
+
+func TestProxy_DefaultIndex_ServesResolvedIndexETag(t *testing.T) {
+	newIndexServer := func(t *testing.T) *Server {
+		t.Helper()
+		s := newTestServer(t, []fakestorage.Object{{
+			ObjectAttrs: fakestorage.ObjectAttrs{
+				BucketName:  testBucket,
+				Name:        "foo/index.html",
+				ContentType: "text/html",
+				Etag:        "idx1",
+				Updated:     testUpdated,
+			},
+			Content: []byte(testIndexBody),
+		}})
+		s.defaultIndex = "index.html"
+		return s
+	}
+
+	t.Run("resolved index carries its ETag", func(t *testing.T) {
+		s := newIndexServer(t)
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/"+testBucket+"/foo/", nil)
+		s.handler().ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d (body=%q)", rec.Code, http.StatusOK, rec.Body.String())
+		}
+		if got := rec.Header().Get("ETag"); got != `"idx1"` {
+			t.Errorf("ETag = %q, want %q", got, `"idx1"`)
+		}
+	})
+
+	t.Run("revalidation returns 304", func(t *testing.T) {
+		s := newIndexServer(t)
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/"+testBucket+"/foo/", nil)
+		req.Header.Set("If-None-Match", `"idx1"`)
+		s.handler().ServeHTTP(rec, req)
+		if rec.Code != http.StatusNotModified {
+			t.Errorf("status = %d, want %d", rec.Code, http.StatusNotModified)
+		}
+	})
+}
+
+func TestProxy_WalkUpIndex_Conditional(t *testing.T) {
+	s := newTestServer(t, []fakestorage.Object{{
+		ObjectAttrs: fakestorage.ObjectAttrs{
+			BucketName:  testBucket,
+			Name:        "foo/index.html",
+			ContentType: "text/html",
+			Etag:        "idx1",
+			Updated:     testUpdated,
+		},
+		Content: []byte(testIndexBody),
+	}})
+	s.defaultIndex = "index.html"
+	s.walkUpIndex = true
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/"+testBucket+"/foo/bar/search", nil)
+	req.Header.Set("If-None-Match", `"idx1"`)
+	s.handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotModified {
+		t.Fatalf("status = %d, want %d (walk-up resolved index must revalidate)", rec.Code, http.StatusNotModified)
+	}
+	if got := rec.Header().Get("ETag"); got != `"idx1"` {
+		t.Errorf("ETag = %q, want %q", got, `"idx1"`)
+	}
+}
+
+func TestProxy_GenerationPinnedRead_Smoke(t *testing.T) {
+	// Readers are pinned to the attrs' generation; both reader types must
+	// round-trip the generation parameter through the (fake) GCS API.
+	s := newTestServer(t, []fakestorage.Object{{
+		ObjectAttrs: fakestorage.ObjectAttrs{
+			BucketName: testBucket,
+			Name:       testObject,
+			Etag:       testEtag,
+			Generation: 1234,
+		},
+		Content: []byte(testContent),
+	}})
+
+	t.Run("full read", func(t *testing.T) {
+		rec := doRequest(t, s, http.MethodGet, nil)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d (body=%q)", rec.Code, http.StatusOK, rec.Body.String())
+		}
+		if got := rec.Body.String(); got != testContent {
+			t.Errorf("body = %q, want %q", got, testContent)
+		}
+	})
+
+	t.Run("range read", func(t *testing.T) {
+		rec := doRequest(t, s, http.MethodGet, map[string]string{"Range": "bytes=2-5"})
+		if rec.Code != http.StatusPartialContent {
+			t.Fatalf("status = %d, want %d (body=%q)", rec.Code, http.StatusPartialContent, rec.Body.String())
+		}
+		if got := rec.Body.String(); got != testContent[2:6] {
+			t.Errorf("body = %q, want %q", got, testContent[2:6])
 		}
 	})
 }


### PR DESCRIPTION
Since GCS computes ETags for all objects, we can add conditional HTTP requests support for ETag/If-None-Match and allow also potentially re-uploaded but identical (identical content hash, ETag) to be responded with 304 and cached by intermediary proxies/caches/CDNs.

Emit the GCS object etag as the ETag header on all object responses and evaluate the complete precondition set for this GET/HEAD proxy:
- If-None-Match (weak comparison, lists, "*") → 304; when present, If-Modified-Since is ignored as RFC 9110 requires
- If-Match / If-Unmodified-Since → 412 Precondition Failed
- If-Range: strong etag or exact Last-Modified date, otherwise the Range header is ignored and the full body served - a resumed download can no longer mix bytes from two object versions
- All three HTTP-date formats; invalid dates, malformed entity-tags, and empty conditional headers are ignored per net/http semantics

Preconditions run before Range processing and also cover default-index, walk-up, and SPA fallback responses (against the resolved object's etag); the -not-found 404 page is never conditional.

Gzip-stored objects get a weak W/"..." etag plus Vary: Accept-Encoding, since the same URL serves raw-gzip or GCS-transcoded bytes depending on the request's Accept-Encoding.

Also fixed:
- 304 responses now carry ETag/Last-Modified/Cache-Control instead of a bare status line
- objects with unknown (zero) Updated no longer answer 304 to any If-Modified-Since; date conditionals are disabled for them
- reads are pinned to the generation the validators came from, so a concurrent overwrite cannot pair a new body with stale validators